### PR TITLE
Add ability for `view t/TAG` to view persons with specified tags

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_RACE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RELIGION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SURVEY;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -43,51 +44,34 @@ public class ViewCommandParser implements Parser<ViewCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
         }
 
-        Optional<String> nameStringOptional = argMultimap.getValue(PREFIX_NAME);
-        Optional<String> phoneStringOptional = argMultimap.getValue(PREFIX_PHONE);
-        Optional<String> emailStringOptional = argMultimap.getValue(PREFIX_EMAIL);
-        Optional<String> addressStringOptional = argMultimap.getValue(PREFIX_ADDRESS);
-        Optional<String> genderStringOptional = argMultimap.getValue(PREFIX_GENDER);
-        Optional<String> birthdateStringOptional = argMultimap.getValue(PREFIX_BIRTHDATE);
-        Optional<String> raceStringOptional = argMultimap.getValue(PREFIX_RACE);
-        Optional<String> religionStringOptional = argMultimap.getValue(PREFIX_RELIGION);
-        Optional<String> surveyStringOptional = argMultimap.getValue(PREFIX_SURVEY);
-
-        String[] nameKeywords = nameStringOptional.isEmpty() ? new String[] {}
-                : nameStringOptional.get().trim().split("\\s+");
-        String[] phoneKeywords = phoneStringOptional.isEmpty() ? new String[] {}
-                : phoneStringOptional.get().trim().split("\\s+");
-        String[] emailKeywords = emailStringOptional.isEmpty() ? new String[] {}
-                : emailStringOptional.get().trim().split("\\s+");
-        String[] addressKeywords = addressStringOptional.isEmpty() ? new String[] {}
-                : addressStringOptional.get().trim().split("\\s+");
-        String[] genderKeywords = genderStringOptional.isEmpty() ? new String[] {}
-                : genderStringOptional.get().trim().split("\\s+");
-        String[] birthdateKeywords = birthdateStringOptional.isEmpty() ? new String[] {}
-                : birthdateStringOptional.get().trim().split("\\s+");
-        String[] raceKeywords = raceStringOptional.isEmpty() ? new String[] {}
-                : raceStringOptional.get().trim().split("\\s+");
-        String[] religionKeywords = religionStringOptional.isEmpty() ? new String[] {}
-                : religionStringOptional.get().trim().split("\\s+");
-        String[] surveyKeywords = surveyStringOptional.isEmpty() ? new String[] {}
-                : surveyStringOptional.get().trim().split("\\s+");
-
-        List<String> nameList = Arrays.asList(nameKeywords);
-        List<String> phoneList = Arrays.asList(phoneKeywords);
-        List<String> emailList = Arrays.asList(emailKeywords);
-        List<String> addressList = Arrays.asList(addressKeywords);
-        List<String> genderList = Arrays.asList(genderKeywords);
-        List<String> birthdateList = Arrays.asList(birthdateKeywords);
-        List<String> raceList = Arrays.asList(raceKeywords);
-        List<String> religionList = Arrays.asList(religionKeywords);
-        List<String> surveyList = Arrays.asList(surveyKeywords);
+        List<String> nameList = getKeywordsAsList(argMultimap.getValue(PREFIX_NAME));
+        List<String> phoneList = getKeywordsAsList(argMultimap.getValue(PREFIX_PHONE));
+        List<String> emailList = getKeywordsAsList(argMultimap.getValue(PREFIX_EMAIL));
+        List<String> addressList = getKeywordsAsList(argMultimap.getValue(PREFIX_ADDRESS));
+        List<String> genderList = getKeywordsAsList(argMultimap.getValue(PREFIX_GENDER));
+        List<String> birthdateList = getKeywordsAsList(argMultimap.getValue(PREFIX_BIRTHDATE));
+        List<String> raceList = getKeywordsAsList(argMultimap.getValue(PREFIX_RACE));
+        List<String> religionList = getKeywordsAsList(argMultimap.getValue(PREFIX_RELIGION));
+        List<String> surveyList = getKeywordsAsList(argMultimap.getValue(PREFIX_SURVEY));
 
         return new ViewCommand(new PersonContainsAttributePredicate(nameList, phoneList, emailList, addressList,
                 genderList, birthdateList, raceList, religionList, surveyList));
     }
 
     /**
-     * Returns true if some of the prefixes contains empty {@code Optional} values in the given
+     * Parses the given (possibly empty) {@code attributeStringOptional} of a given prefix.
+     * @return A list of {@code String} of keywords associated to the given prefix.
+     * If no keywords were specified, returns an empty {@code ArrayList)
+     */
+    private static List<String> getKeywordsAsList(Optional<String> attributeStringOptional) {
+        return attributeStringOptional
+                .map(arg -> arg.trim().split("\\s+"))
+                .map(Arrays::asList)
+                .orElse(new ArrayList<>());
+    }
+
+    /**
+     * Returns true if some prefixes contains empty {@code Optional} values in the given
      * {@code ArgumentMultimap}.
      */
     private static boolean areAnyPrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -10,16 +10,19 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RACE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RELIGION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SURVEY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.PersonContainsAttributePredicate;
+import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -35,10 +38,12 @@ public class ViewCommandParser implements Parser<ViewCommand> {
 
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_GENDER, PREFIX_BIRTHDATE, PREFIX_RACE, PREFIX_RELIGION, PREFIX_SURVEY);
+                        PREFIX_GENDER, PREFIX_BIRTHDATE, PREFIX_RACE, PREFIX_RELIGION, PREFIX_SURVEY,
+                        PREFIX_TAG);
 
         if (!areAnyPrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                PREFIX_GENDER, PREFIX_BIRTHDATE, PREFIX_RACE, PREFIX_RELIGION, PREFIX_SURVEY)
+                PREFIX_GENDER, PREFIX_BIRTHDATE, PREFIX_RACE, PREFIX_RELIGION, PREFIX_SURVEY,
+                PREFIX_TAG)
                 || !argMultimap.getPreamble().isEmpty()
                 || args.trim().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE));
@@ -54,8 +59,13 @@ public class ViewCommandParser implements Parser<ViewCommand> {
         List<String> religionList = getKeywordsAsList(argMultimap.getValue(PREFIX_RELIGION));
         List<String> surveyList = getKeywordsAsList(argMultimap.getValue(PREFIX_SURVEY));
 
-        return new ViewCommand(new PersonContainsAttributePredicate(nameList, phoneList, emailList, addressList,
-                genderList, birthdateList, raceList, religionList, surveyList));
+        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        PersonContainsAttributePredicate predicate = new PersonContainsAttributePredicate(nameList, phoneList,
+                emailList, addressList, genderList, birthdateList, raceList, religionList, surveyList,
+                tagList);
+
+        return new ViewCommand(predicate);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -70,8 +70,7 @@ public class ViewCommandParser implements Parser<ViewCommand> {
 
     /**
      * Parses the given (possibly empty) {@code attributeStringOptional} of a given prefix.
-     * @return A list of {@code String} of keywords associated to the given prefix and returns
-     * an empty {@code ArrayList) if {@code attributeStringOptional} is empty.
+     * @return A list of {@code String} of keywords associated to the given prefix.
      */
     private static List<String> getKeywordsAsList(Optional<String> attributeStringOptional) {
         return attributeStringOptional

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -70,8 +70,8 @@ public class ViewCommandParser implements Parser<ViewCommand> {
 
     /**
      * Parses the given (possibly empty) {@code attributeStringOptional} of a given prefix.
-     * @return A list of {@code String} of keywords associated to the given prefix.
-     * If no keywords were specified, returns an empty {@code ArrayList)
+     * @return A list of {@code String} of keywords associated to the given prefix and returns
+     * an empty {@code ArrayList) if {@code attributeStringOptional} is empty.
      */
     private static List<String> getKeywordsAsList(Optional<String> attributeStringOptional) {
         return attributeStringOptional

--- a/src/main/java/seedu/address/model/person/PersonContainsAttributePredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsAttributePredicate.java
@@ -1,9 +1,11 @@
 package seedu.address.model.person;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
+import seedu.address.model.tag.Tag;
 
 /**
  * Tests that a {@code Person}'s attributes matches any of the keywords given for each attribute.
@@ -19,13 +21,15 @@ public class PersonContainsAttributePredicate implements Predicate<Person> {
     private final List<String> raceList;
     private final List<String> religionList;
     private final List<String> surveyList;
+    private final Set<Tag> tagsList;
 
     /**
      * Every field must be non-null.
      */
     public PersonContainsAttributePredicate(List<String> nameList, List<String> phoneList, List<String> emailList,
-                                    List<String> addressList, List<String> genderList, List<String> birthdateList,
-                                    List<String> raceList, List<String> religionList, List<String> surveyList) {
+                                            List<String> addressList, List<String> genderList, List<String> birthdateList,
+                                            List<String> raceList, List<String> religionList, List<String> surveyList,
+                                            Set<Tag> tagsList) {
 
         this.nameList = nameList;
         this.phoneList = phoneList;
@@ -36,6 +40,7 @@ public class PersonContainsAttributePredicate implements Predicate<Person> {
         this.raceList = raceList;
         this.religionList = religionList;
         this.surveyList = surveyList;
+        this.tagsList = tagsList;
     }
 
     @Override
@@ -59,9 +64,11 @@ public class PersonContainsAttributePredicate implements Predicate<Person> {
                 .anyMatch(doesKeywordMatchWith(person.getReligion().religion));
         boolean containsSurvey = surveyList.isEmpty() || surveyList.stream()
                 .anyMatch(doesKeywordMatchWith(person.getSurvey().survey));
+        boolean containsTags = tagsList.isEmpty() || person.getTags().containsAll(tagsList);
 
         return (containsName && containsPhone && containsEmail && containsAddress && containsGender
-                && containsBirthdate && containsRace && containsReligion && containsSurvey);
+                && containsBirthdate && containsRace && containsReligion && containsSurvey
+                && containsTags);
     }
 
     public Predicate<String> doesKeywordMatchWith(String targetString) {
@@ -80,7 +87,8 @@ public class PersonContainsAttributePredicate implements Predicate<Person> {
                 && birthdateList.equals(((PersonContainsAttributePredicate) other).birthdateList)
                 && raceList.equals(((PersonContainsAttributePredicate) other).raceList)
                 && religionList.equals(((PersonContainsAttributePredicate) other).religionList)
-                && surveyList.equals(((PersonContainsAttributePredicate) other).surveyList)); //state check
+                && surveyList.equals(((PersonContainsAttributePredicate) other).surveyList)
+                && tagsList.equals(((PersonContainsAttributePredicate) other).tagsList)); //state check
     }
 
 }

--- a/src/main/java/seedu/address/model/person/PersonContainsAttributePredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsAttributePredicate.java
@@ -27,9 +27,9 @@ public class PersonContainsAttributePredicate implements Predicate<Person> {
      * Every field must be non-null.
      */
     public PersonContainsAttributePredicate(List<String> nameList, List<String> phoneList, List<String> emailList,
-                                            List<String> addressList, List<String> genderList, List<String> birthdateList,
-                                            List<String> raceList, List<String> religionList, List<String> surveyList,
-                                            Set<Tag> tagsList) {
+                                        List<String> addressList, List<String> genderList, List<String> birthdateList,
+                                        List<String> raceList, List<String> religionList, List<String> surveyList,
+                                        Set<Tag> tagsList) {
 
         this.nameList = nameList;
         this.phoneList = phoneList;

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -13,13 +13,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.HashSet;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 import seedu.address.model.person.PersonContainsAttributePredicate;
+import seedu.address.model.UserPrefs;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code ViewCommand}.
@@ -33,11 +34,13 @@ public class ViewCommandTest {
         PersonContainsAttributePredicate firstPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("male"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new HashSet<>());
         PersonContainsAttributePredicate secondPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("female"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new HashSet<>());
 
         ViewCommand viewFirstCommand = new ViewCommand(firstPredicate);
         ViewCommand viewSecondCommand = new ViewCommand(secondPredicate);
@@ -64,12 +67,13 @@ public class ViewCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        PersonContainsAttributePredicate predicate =
+        PersonContainsAttributePredicate testPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("r4nd0m_inV4l1d_g3nd3r"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
-        ViewCommand command = new ViewCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new HashSet<>());
+        ViewCommand command = new ViewCommand(testPredicate);
+        expectedModel.updateFilteredPersonList(testPredicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
@@ -77,12 +81,13 @@ public class ViewCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
-        PersonContainsAttributePredicate predicate =
+        PersonContainsAttributePredicate testPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("female"), new ArrayList<>(),
-                        new ArrayList<>(), List.of("christian"), new ArrayList<>());
-        ViewCommand command = new ViewCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+                        new ArrayList<>(), List.of("christian"), new ArrayList<>(),
+                        new HashSet<>());
+        ViewCommand command = new ViewCommand(testPredicate);
+        expectedModel.updateFilteredPersonList(testPredicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(ALICE, FIONA), model.getFilteredPersonList());
     }

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -12,8 +12,8 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.HashSet;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.person.PersonContainsAttributePredicate;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.PersonContainsAttributePredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code ViewCommand}.

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -32,10 +33,12 @@ public class ViewCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
-        ViewCommand expectedViewCommand =
-                new ViewCommand(new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
+        PersonContainsAttributePredicate testPredicate =
+                new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("male"), new ArrayList<>(),
-                        List.of("chinese"), new ArrayList<>(), new ArrayList<>()));
+                        List.of("chinese"), new ArrayList<>(), new ArrayList<>(),
+                        new HashSet<>());
+        ViewCommand expectedViewCommand = new ViewCommand(testPredicate);
 
         assertParseSuccess(parser, " g/male ra/chinese", expectedViewCommand);
 

--- a/src/test/java/seedu/address/model/person/PersonContainsAttributePredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsAttributePredicateTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -18,11 +19,13 @@ public class PersonContainsAttributePredicateTest {
         PersonContainsAttributePredicate firstPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("male"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new HashSet<>());
         PersonContainsAttributePredicate secondPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("female"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new HashSet<>());
 
         ViewCommand viewFirstCommand = new ViewCommand(firstPredicate);
         ViewCommand viewSecondCommand = new ViewCommand(secondPredicate);
@@ -51,27 +54,31 @@ public class PersonContainsAttributePredicateTest {
         PersonContainsAttributePredicate predicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("male"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new HashSet<>());
         assertTrue(predicate.test(new PersonBuilder().withGender("male").build()));
 
         // Multiple keywords
         predicate =
                 new PersonContainsAttributePredicate(List.of("Alice", "Bob"), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new HashSet<>());
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Only one matching keyword
         predicate =
                 new PersonContainsAttributePredicate(List.of("Bob", "Carol"), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new HashSet<>());
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
 
         // Mixed-case keywords
         new PersonContainsAttributePredicate(List.of("aLiCe", "bOb"), new ArrayList<>(),
                 new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
-                new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                new HashSet<>());
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 
@@ -81,7 +88,8 @@ public class PersonContainsAttributePredicateTest {
         PersonContainsAttributePredicate predicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("r4nd0m_inV4l1d_g3nd3r"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new HashSet<>());
         assertFalse(predicate.test(new PersonBuilder().withGender("female").build()));
 
     }


### PR DESCRIPTION
Implements #88, which the previous iteration did not support. Here, `view` allows users to input multiple tags as parameters, which returns users with _all_ the specified tags. This is unlike other attributes that only interprets the _last_ prefix. 

For example

- `view g/male g/female` returns a list of all persons with gender containing the word `female`. (ignores `g/male`)
- `view t/friends t/collegues` returns a list of all persons with the tags `friends` **and** `colleagues`.

For consistency, this behaviour follows that of the `add` command (by @KeithPJX), since

- `add n/John Doe n/Jane Doe ...` adds a person with the name `Jane Doe`. (ignores `n/John Doe`)
- `add ... t/friends t/collegues` adds a person with the tags `friends` **and** `colleagues`.

I welcome any suggestions on ways to improve the `view` functionality!

Also abstracted repeated code in the `ViewCommandParser` class (thanks @deepimpactmir for the suggestions).