### PR TITLE
Allow `Person` to have multiple `Survey` objects

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CloneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CloneCommand.java
@@ -81,7 +81,8 @@ public class CloneCommand extends Command {
         Birthdate clonedBirthdate = personToClone.getBirthdate();
         Race clonedRace = personToClone.getRace();
         Religion clonedReligion = personToClone.getReligion();
-        Survey clonedSurvey = personToClone.getSurvey();
+
+        Set<Survey> clonedSurvey = (personToClone.getSurveys() != null) ? personToClone.getSurveys() : null;
         Set<Tag> clonedTags = (personToClone.getTags() != null) ? personToClone.getTags() : null;
 
         Person clonedPerson = new Person(updatedName, clonedPhone, clonedEmail, clonedAddress,

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -70,7 +70,8 @@ public class DeleteCommand extends Command {
 
         Predicate<Person> predicate = x -> x.getRace().equals(race.orElse(x.getRace()))
                 && x.getReligion().equals(religion.orElse(x.getReligion()))
-                && x.getSurvey().equals(survey.orElse(x.getSurvey()));
+                && x.getSurveys().contains(survey.orElse(x.getSurveys().iterator().next()));
+
         String str = model.deletePersons(predicate);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, str));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -106,7 +106,7 @@ public class EditCommand extends Command {
         Birthdate updatedBirthdate = editPersonDescriptor.getBirthdate().orElse(personToEdit.getBirthdate());
         Race updatedRace = editPersonDescriptor.getRace().orElse(personToEdit.getRace());
         Religion updatedReligion = editPersonDescriptor.getReligion().orElse(personToEdit.getReligion());
-        Survey updatedSurvey = editPersonDescriptor.getSurvey().orElse(personToEdit.getSurvey());
+        Set<Survey> updatedSurvey = editPersonDescriptor.getSurveys().orElse(personToEdit.getSurveys());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,
@@ -145,7 +145,8 @@ public class EditCommand extends Command {
         private Birthdate birthdate;
         private Race race;
         private Religion religion;
-        private Survey survey;
+
+        private Set<Survey> surveys;
         private Set<Tag> tags;
 
         public EditPersonDescriptor() {}
@@ -163,7 +164,8 @@ public class EditCommand extends Command {
             setBirthdate(toCopy.birthdate);
             setRace(toCopy.race);
             setReligion(toCopy.religion);
-            setSurvey(toCopy.survey);
+
+            setSurveys(toCopy.surveys);
             setTags(toCopy.tags);
         }
 
@@ -238,12 +240,21 @@ public class EditCommand extends Command {
             return Optional.ofNullable(religion);
         }
 
-        public void setSurvey(Survey survey) {
-            this.survey = survey;
+        /**
+         * Sets {@code surveys} to this object's {@code surveys}.
+         * A defensive copy of {@code surveys} is used internally.
+         */
+        public void setSurveys(Set<Survey> surveys) {
+            this.surveys = (surveys != null) ? new HashSet<>(surveys) : null;
         }
 
-        public Optional<Survey> getSurvey() {
-            return Optional.ofNullable(survey);
+        /**
+         * Returns an unmodifiable survey set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code surveys} is null.
+         */
+        public Optional<Set<Survey>> getSurveys() {
+            return (surveys != null) ? Optional.of(Collections.unmodifiableSet(surveys)) : Optional.empty();
         }
 
         /**

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -58,10 +58,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         Birthdate birthdate = ParserUtil.parseBirthdate(argMultimap.getValue(PREFIX_BIRTHDATE).get());
         Race race = ParserUtil.parseRace(argMultimap.getValue(PREFIX_RACE).get());
         Religion religion = ParserUtil.parseReligion(argMultimap.getValue(PREFIX_RELIGION).get());
-        Survey survey = ParserUtil.parseSurvey(argMultimap.getValue(PREFIX_SURVEY).get());
+        Set<Survey> surveyList = ParserUtil.parseSurveys(argMultimap.getAllValues(PREFIX_SURVEY));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, gender, birthdate, race, religion, survey, tagList);
+        Person person = new Person(name, phone, email, address, gender, birthdate, race, religion, surveyList, tagList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -176,6 +176,18 @@ public class ParserUtil {
     }
 
     /**
+     * Parses {@code Collection<String> surveys} into a {@code Set<Survey>}.
+     */
+    public static Set<Survey> parseSurveys(Collection<String> surveys) throws ParseException {
+        requireNonNull(surveys);
+        final Set<Survey> surveySet = new HashSet<>();
+        for (String surveyName : surveys) {
+            surveySet.add(parseSurvey(surveyName));
+        }
+        return surveySet;
+    }
+
+    /**
      * Parses a {@code String tag} into a {@code Tag}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.PersonContainsAttributePredicate;
+import seedu.address.model.person.Survey;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -57,8 +58,8 @@ public class ViewCommandParser implements Parser<ViewCommand> {
         List<String> birthdateList = getKeywordsAsList(argMultimap.getValue(PREFIX_BIRTHDATE));
         List<String> raceList = getKeywordsAsList(argMultimap.getValue(PREFIX_RACE));
         List<String> religionList = getKeywordsAsList(argMultimap.getValue(PREFIX_RELIGION));
-        List<String> surveyList = getKeywordsAsList(argMultimap.getValue(PREFIX_SURVEY));
 
+        Set<Survey> surveyList = ParserUtil.parseSurveys(argMultimap.getAllValues(PREFIX_SURVEY));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         PersonContainsAttributePredicate predicate = new PersonContainsAttributePredicate(nameList, phoneList,

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -26,7 +26,7 @@ public class Person {
 
     // Data fields
     private final Address address;
-    private final Survey survey;
+    private final Set<Survey> surveys = new HashSet<>();
     private final Set<Tag> tags = new HashSet<>();
 
     /**
@@ -34,10 +34,10 @@ public class Person {
      */
     public Person(Name name, Phone phone, Email email, Address address,
                   Gender gender, Birthdate birthdate, Race race,
-                  Religion religion, Survey survey, Set<Tag> tags) {
+                  Religion religion, Set<Survey> surveys, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address,
                 gender, birthdate, race,
-                religion, survey, tags);
+                religion, surveys, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -46,7 +46,7 @@ public class Person {
         this.birthdate = birthdate;
         this.race = race;
         this.religion = religion;
-        this.survey = survey;
+        this.surveys.addAll(surveys);
         this.tags.addAll(tags);
     }
 
@@ -82,8 +82,12 @@ public class Person {
         return religion;
     }
 
-    public Survey getSurvey() {
-        return survey;
+    /**
+     * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public Set<Survey> getSurveys() {
+        return Collections.unmodifiableSet(surveys);
     }
 
     /**
@@ -111,7 +115,7 @@ public class Person {
                 && otherPerson.getName().equals(getName())
                 && otherPerson.getPhone().equals(getPhone())
                 && otherPerson.getEmail().equals(getEmail())
-                && otherPerson.getSurvey().equals(getSurvey());
+                && otherPerson.getSurveys().equals(getSurveys());
     }
 
     /**
@@ -137,7 +141,7 @@ public class Person {
                 && otherPerson.getBirthdate().equals(getBirthdate())
                 && otherPerson.getRace().equals(getRace())
                 && otherPerson.getReligion().equals(getReligion())
-                && otherPerson.getSurvey().equals(getSurvey())
+                && otherPerson.getSurveys().equals(getSurveys())
                 && otherPerson.getTags().equals(getTags());
     }
 
@@ -145,7 +149,7 @@ public class Person {
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
         return Objects.hash(name, phone, email, address, gender,
-                birthdate, race, religion, survey, tags);
+                birthdate, race, religion, surveys, tags);
     }
 
     @Override
@@ -165,10 +169,13 @@ public class Person {
                 .append("; Race: ")
                 .append(getRace())
                 .append("; Religion: ")
-                .append(getReligion())
-                .append("; Survey: ")
-                .append(getSurvey());
+                .append(getReligion());
 
+        Set<Survey> surveys = getSurveys();
+        if (!surveys.isEmpty()) {
+            builder.append("; Surveys: ");
+            surveys.forEach(builder::append);
+        }
 
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {

--- a/src/main/java/seedu/address/model/person/PersonContainsAttributePredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsAttributePredicate.java
@@ -20,7 +20,7 @@ public class PersonContainsAttributePredicate implements Predicate<Person> {
     private final List<String> birthdateList;
     private final List<String> raceList;
     private final List<String> religionList;
-    private final List<String> surveyList;
+    private final Set<Survey> surveysList;
     private final Set<Tag> tagsList;
 
     /**
@@ -28,7 +28,7 @@ public class PersonContainsAttributePredicate implements Predicate<Person> {
      */
     public PersonContainsAttributePredicate(List<String> nameList, List<String> phoneList, List<String> emailList,
                                         List<String> addressList, List<String> genderList, List<String> birthdateList,
-                                        List<String> raceList, List<String> religionList, List<String> surveyList,
+                                        List<String> raceList, List<String> religionList, Set<Survey> surveysList,
                                         Set<Tag> tagsList) {
 
         this.nameList = nameList;
@@ -39,7 +39,7 @@ public class PersonContainsAttributePredicate implements Predicate<Person> {
         this.birthdateList = birthdateList;
         this.raceList = raceList;
         this.religionList = religionList;
-        this.surveyList = surveyList;
+        this.surveysList = surveysList;
         this.tagsList = tagsList;
     }
 
@@ -62,8 +62,8 @@ public class PersonContainsAttributePredicate implements Predicate<Person> {
                 .anyMatch(doesKeywordMatchWith(person.getRace().race));
         boolean containsReligion = religionList.isEmpty() || religionList.stream()
                 .anyMatch(doesKeywordMatchWith(person.getReligion().religion));
-        boolean containsSurvey = surveyList.isEmpty() || surveyList.stream()
-                .anyMatch(doesKeywordMatchWith(person.getSurvey().survey));
+
+        boolean containsSurvey = surveysList.isEmpty() || person.getSurveys().containsAll(surveysList);
         boolean containsTags = tagsList.isEmpty() || person.getTags().containsAll(tagsList);
 
         return (containsName && containsPhone && containsEmail && containsAddress && containsGender
@@ -87,7 +87,7 @@ public class PersonContainsAttributePredicate implements Predicate<Person> {
                 && birthdateList.equals(((PersonContainsAttributePredicate) other).birthdateList)
                 && raceList.equals(((PersonContainsAttributePredicate) other).raceList)
                 && religionList.equals(((PersonContainsAttributePredicate) other).religionList)
-                && surveyList.equals(((PersonContainsAttributePredicate) other).surveyList)
+                && surveysList.equals(((PersonContainsAttributePredicate) other).surveysList)
                 && tagsList.equals(((PersonContainsAttributePredicate) other).tagsList)); //state check
     }
 

--- a/src/main/java/seedu/address/model/person/Survey.java
+++ b/src/main/java/seedu/address/model/person/Survey.java
@@ -35,11 +35,6 @@ public class Survey {
     }
 
     @Override
-    public String toString() {
-        return survey;
-    }
-
-    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Survey // instanceof handles nulls
@@ -49,5 +44,12 @@ public class Survey {
     @Override
     public int hashCode() {
         return survey.hashCode();
+    }
+
+    /**
+     * Format state as text for viewing.
+     */
+    public String toString() {
+        return '[' + survey + ']';
     }
 }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -27,27 +27,33 @@ public class SampleDataUtil {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), new Gender("male"),
                 new Birthdate("1989-10-12"), new Race("Chinese"), new Religion("Buddhist"),
-                new Survey("Environment Survey"), getTagSet("friends")),
+                getSurveySet("Environment Survey", "Changi Airport Survey"),
+                getTagSet("friends")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Gender("female"),
                 new Birthdate("1995-01-28"), new Race("Chinese"), new Religion("Christian"),
-                new Survey("Changi Airport Survey"), getTagSet("colleagues", "friends")),
+                getSurveySet("Changi Airport Survey", "Environment Survey"),
+                getTagSet("colleagues", "friends")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Gender("female"),
                 new Birthdate("2001-06-06"), new Race("Italian"), new Religion("Christian"),
-                new Survey("Environment Survey"), getTagSet("neighbours")),
+                getSurveySet("Environment Survey", "Academic Survey"),
+                getTagSet("neighbours")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Gender("male"),
                 new Birthdate("1978-04-25"), new Race("Chinese"), new Religion("Free Thinker"),
-                new Survey("Academic Survey"), getTagSet("family")),
+                getSurveySet("Academic Survey"),
+                getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), new Gender("male"),
                 new Birthdate("1991-08-21"), new Race("Malay"), new Religion("Muslim"),
-                new Survey("Academic Survey"), getTagSet("classmates")),
+                getSurveySet("Academic Survey"),
+                getTagSet("classmates")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), new Gender("male"),
                 new Birthdate("1995-04-01"), new Race("Indian"), new Religion("Hinduism"),
-                new Survey("Changi Airport Survey"), getTagSet("colleagues"))
+                getSurveySet("Changi Airport Survey"),
+                getTagSet("colleagues"))
         };
     }
 
@@ -57,6 +63,15 @@ public class SampleDataUtil {
             sampleAb.addPerson(samplePerson);
         }
         return sampleAb;
+    }
+
+    /**
+     * Returns a survey set containing the list of strings given.
+     */
+    public static Set<Survey> getSurveySet(String... strings) {
+        return Arrays.stream(strings)
+                .map(Survey::new)
+                .collect(Collectors.toSet());
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -50,7 +50,8 @@ class JsonAdaptedPerson {
             @JsonProperty("email") String email, @JsonProperty("address") String address,
             @JsonProperty("gender") String gender, @JsonProperty("birthdate") String birthdate,
             @JsonProperty("race") String race, @JsonProperty("religion") String religion,
-            @JsonProperty("survey") List<JsonAdaptedSurvey> survey, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+            @JsonProperty("survey") List<JsonAdaptedSurvey> survey,
+            @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.name = name;
         this.phone = phone;
         this.email = email;

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -39,7 +39,7 @@ class JsonAdaptedPerson {
     private final String birthdate;
     private final String race;
     private final String religion;
-    private final List<JsonAdaptedSurvey> survey = new ArrayList<>();
+    private final List<JsonAdaptedSurvey> surveys = new ArrayList<>();
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     /**
@@ -50,7 +50,7 @@ class JsonAdaptedPerson {
             @JsonProperty("email") String email, @JsonProperty("address") String address,
             @JsonProperty("gender") String gender, @JsonProperty("birthdate") String birthdate,
             @JsonProperty("race") String race, @JsonProperty("religion") String religion,
-            @JsonProperty("survey") List<JsonAdaptedSurvey> survey,
+            @JsonProperty("surveys") List<JsonAdaptedSurvey> surveys,
             @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.name = name;
         this.phone = phone;
@@ -60,8 +60,8 @@ class JsonAdaptedPerson {
         this.birthdate = birthdate;
         this.race = race;
         this.religion = religion;
-        if (survey != null) {
-            this.survey.addAll(survey);
+        if (surveys != null) {
+            this.surveys.addAll(surveys);
         }
         if (tagged != null) {
             this.tagged.addAll(tagged);
@@ -69,7 +69,7 @@ class JsonAdaptedPerson {
     }
 
     /**
-     * Converts a given {@code PJsonAdaptedTagerson} into this class for Jackson use.
+     * Converts a given {@code Person} into this class for Jackson use.
      */
     public JsonAdaptedPerson(Person source) {
         name = source.getName().fullName;
@@ -80,7 +80,7 @@ class JsonAdaptedPerson {
         birthdate = source.getBirthdate().birthdate.format(DateTimeFormatter.ofPattern(DATE_FORMAT));
         race = source.getRace().race;
         religion = source.getReligion().religion;
-        survey.addAll(source.getSurveys().stream()
+        surveys.addAll(source.getSurveys().stream()
                 .map(JsonAdaptedSurvey::new)
                 .collect(Collectors.toList()));
         tagged.addAll(source.getTags().stream()
@@ -97,7 +97,7 @@ class JsonAdaptedPerson {
         final List<Tag> personTags = new ArrayList<>();
         final List<Survey> personSurveys = new ArrayList<>();
 
-        for (JsonAdaptedSurvey survey : survey) {
+        for (JsonAdaptedSurvey survey : surveys) {
             personSurveys.add(survey.toModelType());
         }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedSurvey.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedSurvey.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Survey;
 
@@ -13,7 +14,7 @@ class JsonAdaptedSurvey {
     private final String surveyName;
 
     /**
-     * Constructs a {@code JsonAdaptedTag} with the given {@code tagName}.
+     * Constructs a {@code JsonAdaptedSurvey} with the given {@code surveyName}.
      */
     @JsonCreator
     public JsonAdaptedSurvey(String surveyName) {
@@ -21,7 +22,7 @@ class JsonAdaptedSurvey {
     }
 
     /**
-     * Converts a given {@code Tag} into this class for Jackson use.
+     * Converts a given {@code Survey} into this class for Jackson use.
      */
     public JsonAdaptedSurvey(Survey source) {
         surveyName = source.survey;
@@ -33,7 +34,7 @@ class JsonAdaptedSurvey {
     }
 
     /**
-     * Converts this Jackson-friendly adapted tag object into the model's {@code Tag} object.
+     * Converts this Jackson-friendly adapted tag object into the model's {@code Survey} object.
      *
      * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
      */

--- a/src/main/java/seedu/address/storage/JsonAdaptedSurvey.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedSurvey.java
@@ -1,0 +1,47 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.Survey;
+
+/**
+ * Jackson-friendly version of {@link Survey}.
+ */
+class JsonAdaptedSurvey {
+
+    private final String surveyName;
+
+    /**
+     * Constructs a {@code JsonAdaptedTag} with the given {@code tagName}.
+     */
+    @JsonCreator
+    public JsonAdaptedSurvey(String surveyName) {
+        this.surveyName = surveyName;
+    }
+
+    /**
+     * Converts a given {@code Tag} into this class for Jackson use.
+     */
+    public JsonAdaptedSurvey(Survey source) {
+        surveyName = source.survey;
+    }
+
+    @JsonValue
+    public String getTagName() {
+        return surveyName;
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted tag object into the model's {@code Tag} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
+     */
+    public Survey toModelType() throws IllegalValueException {
+        if (!Survey.isValidSurvey(surveyName)) {
+            throw new IllegalValueException(Survey.MESSAGE_CONSTRAINTS);
+        }
+        return new Survey(surveyName);
+    }
+
+}

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -50,7 +50,7 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label religion;
     @FXML
-    private Label survey;
+    private FlowPane surveys;
     @FXML
     private FlowPane tags;
 
@@ -69,7 +69,11 @@ public class PersonCard extends UiPart<Region> {
         birthdate.setText(person.getBirthdate().birthdate.format(DateTimeFormatter.ofPattern(DATE_FORMAT)));
         race.setText(person.getRace().race);
         religion.setText(person.getReligion().religion);
-        survey.setText(person.getSurvey().survey);
+
+        person.getSurveys().stream()
+                .sorted(Comparator.comparing(survey -> survey.survey))
+                .forEach(survey -> surveys.getChildren().add(new Label(survey.survey)));
+
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -350,3 +350,17 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+
+#surveys {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#surveys .label {
+    -fx-text-fill: white;
+    -fx-background-color: #3e9144;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -352,3 +352,17 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+
+#surveys {
+    -fx-hgap: 7;
+    -fx-vgap: 3;
+}
+
+#surveys .label {
+    -fx-text-fill: white;
+    -fx-background-color: #3e9144;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -27,6 +27,7 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
+      <FlowPane fx:id="surveys" />
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
@@ -35,7 +36,6 @@
       <Label fx:id="birthdate" styleClass="cell_small_label" text="\$birthdate" />
       <Label fx:id="race" styleClass="cell_small_label" text="\$race" />
       <Label fx:id="religion" styleClass="cell_small_label" text="\$religion" />
-      <Label fx:id="survey" styleClass="cell_small_label" text="\$survey" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -8,7 +8,7 @@
     "birthdate": "2000-1-1",
     "race": "Chinese",
     "religion" : "Buddhist",
-    "survey" : [ "Food Survey" ],
+    "surveys" : [ "Food Survey" ],
     "tagged": [ "friends" ]
   }, {
     "name": "Alice Pauline",
@@ -19,6 +19,6 @@
     "birthdate": "1999-11-28",
     "race": "White American",
     "religion" : "Christian",
-    "survey" : [ "Food Survey" ]
+    "surveys" : [ "Food Survey" ]
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -8,7 +8,7 @@
     "birthdate": "2000-1-1",
     "race": "Chinese",
     "religion" : "Buddhist",
-    "survey" : "Food Survey",
+    "survey" : [ "Food Survey" ],
     "tagged": [ "friends" ]
   }, {
     "name": "Alice Pauline",
@@ -19,6 +19,6 @@
     "birthdate": "1999-11-28",
     "race": "White American",
     "religion" : "Christian",
-    "survey" : "Food Survey"
+    "survey" : [ "Food Survey" ]
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -9,7 +9,7 @@
     "birthdate" : "1998-12-28",
     "race" : "White American",
     "religion" : "Christian",
-    "survey" : [ "Environment Survey" ],
+    "surveys" : [ "Environment Survey" ],
     "tagged" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
@@ -20,7 +20,7 @@
     "birthdate" : "1981-1-23",
     "race" : "African American",
     "religion" : "Christian",
-    "survey" : [ "Shopping Survey" ],
+    "surveys" : [ "Shopping Survey" ],
     "tagged" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
@@ -31,7 +31,7 @@
     "birthdate" : "1991-1-15",
     "race" : "White American",
     "religion" : "Buddhist",
-    "survey" : [ "Touring Survey" ],
+    "surveys" : [ "Touring Survey" ],
     "tagged" : [ ]
   }, {
     "name" : "Daniel Meier",
@@ -42,7 +42,7 @@
     "birthdate" : "2001-11-23",
     "race" : "Hispanic",
     "religion" : "Christian",
-    "survey" : [ "Shopping Survey" ],
+    "surveys" : [ "Shopping Survey" ],
     "tagged" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
@@ -53,7 +53,7 @@
     "birthdate" : "1993-11-1",
     "race" : "White American",
     "religion" : "Free Thinker",
-    "survey" : [ "Touring Survey" ],
+    "surveys" : [ "Touring Survey" ],
     "tagged" : [ ]
   }, {
     "name" : "Fiona Kunz",
@@ -64,7 +64,7 @@
     "birthdate" : "1991-8-13",
     "race" : "White American",
     "religion" : "Christian",
-    "survey" : [ "Food Survey" ],
+    "surveys" : [ "Food Survey" ],
     "tagged" : [ ]
   }, {
     "name" : "George Best",
@@ -75,7 +75,7 @@
     "birthdate" : "1991-12-28",
     "race" : "White American",
     "religion" : "Christian",
-    "survey" : [ "Environment Survey" ],
+    "surveys" : [ "Environment Survey" ],
     "tagged" : [ ]
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -9,7 +9,7 @@
     "birthdate" : "1998-12-28",
     "race" : "White American",
     "religion" : "Christian",
-    "survey" : "Environment Survey",
+    "survey" : [ "Environment Survey" ],
     "tagged" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
@@ -20,7 +20,7 @@
     "birthdate" : "1981-1-23",
     "race" : "African American",
     "religion" : "Christian",
-    "survey" : "Shopping Survey",
+    "survey" : [ "Shopping Survey" ],
     "tagged" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
@@ -31,7 +31,7 @@
     "birthdate" : "1991-1-15",
     "race" : "White American",
     "religion" : "Buddhist",
-    "survey" : "Touring Survey",
+    "survey" : [ "Touring Survey" ],
     "tagged" : [ ]
   }, {
     "name" : "Daniel Meier",
@@ -42,7 +42,7 @@
     "birthdate" : "2001-11-23",
     "race" : "Hispanic",
     "religion" : "Christian",
-    "survey" : "Shopping Survey",
+    "survey" : [ "Shopping Survey" ],
     "tagged" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
@@ -53,7 +53,7 @@
     "birthdate" : "1993-11-1",
     "race" : "White American",
     "religion" : "Free Thinker",
-    "survey" : "Touring Survey",
+    "survey" : [ "Touring Survey" ],
     "tagged" : [ ]
   }, {
     "name" : "Fiona Kunz",
@@ -64,7 +64,7 @@
     "birthdate" : "1991-8-13",
     "race" : "White American",
     "religion" : "Christian",
-    "survey" : "Food Survey",
+    "survey" : [ "Food Survey" ],
     "tagged" : [ ]
   }, {
     "name" : "George Best",
@@ -75,7 +75,7 @@
     "birthdate" : "1991-12-28",
     "race" : "White American",
     "religion" : "Christian",
-    "survey" : "Environment Survey",
+    "survey" : [ "Environment Survey" ],
     "tagged" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -34,12 +34,12 @@ public class ViewCommandTest {
         PersonContainsAttributePredicate firstPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("male"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
                         new HashSet<>());
         PersonContainsAttributePredicate secondPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("female"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
                         new HashSet<>());
 
         ViewCommand viewFirstCommand = new ViewCommand(firstPredicate);
@@ -70,7 +70,7 @@ public class ViewCommandTest {
         PersonContainsAttributePredicate testPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("r4nd0m_inV4l1d_g3nd3r"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
                         new HashSet<>());
         ViewCommand command = new ViewCommand(testPredicate);
         expectedModel.updateFilteredPersonList(testPredicate);
@@ -84,7 +84,7 @@ public class ViewCommandTest {
         PersonContainsAttributePredicate testPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("female"), new ArrayList<>(),
-                        new ArrayList<>(), List.of("christian"), new ArrayList<>(),
+                        new ArrayList<>(), List.of("christian"), new HashSet<>(),
                         new HashSet<>());
         ViewCommand command = new ViewCommand(testPredicate);
         expectedModel.updateFilteredPersonList(testPredicate);

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -31,12 +31,12 @@ public class ViewCommandParserTest {
 
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
+    public void parse_validArgs_returnsViewCommand() {
         // no leading and trailing whitespaces
         PersonContainsAttributePredicate testPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("male"), new ArrayList<>(),
-                        List.of("chinese"), new ArrayList<>(), new ArrayList<>(),
+                        List.of("chinese"), new ArrayList<>(), new HashSet<>(),
                         new HashSet<>());
         ViewCommand expectedViewCommand = new ViewCommand(testPredicate);
 

--- a/src/test/java/seedu/address/model/person/PersonContainsAttributePredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsAttributePredicateTest.java
@@ -19,12 +19,12 @@ public class PersonContainsAttributePredicateTest {
         PersonContainsAttributePredicate firstPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("male"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
                         new HashSet<>());
         PersonContainsAttributePredicate secondPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("female"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
                         new HashSet<>());
 
         ViewCommand viewFirstCommand = new ViewCommand(firstPredicate);
@@ -54,7 +54,7 @@ public class PersonContainsAttributePredicateTest {
         PersonContainsAttributePredicate predicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("male"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
                         new HashSet<>());
         assertTrue(predicate.test(new PersonBuilder().withGender("male").build()));
 
@@ -62,7 +62,7 @@ public class PersonContainsAttributePredicateTest {
         predicate =
                 new PersonContainsAttributePredicate(List.of("Alice", "Bob"), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
                         new HashSet<>());
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
@@ -70,15 +70,16 @@ public class PersonContainsAttributePredicateTest {
         predicate =
                 new PersonContainsAttributePredicate(List.of("Bob", "Carol"), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
                         new HashSet<>());
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
 
         // Mixed-case keywords
-        new PersonContainsAttributePredicate(List.of("aLiCe", "bOb"), new ArrayList<>(),
-                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
-                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
-                new HashSet<>());
+        predicate =
+                new PersonContainsAttributePredicate(List.of("aLiCe", "bOb"), new ArrayList<>(),
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
+                        new HashSet<>());
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 
@@ -88,7 +89,7 @@ public class PersonContainsAttributePredicateTest {
         PersonContainsAttributePredicate predicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("r4nd0m_inV4l1d_g3nd3r"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
                         new HashSet<>());
         assertFalse(predicate.test(new PersonBuilder().withGender("female").build()));
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -40,7 +40,7 @@ public class PersonTest {
         // same name, phone, email and survey -> returns true
         editedAlice = new PersonBuilder().withName(ALICE.getName().fullName)
                 .withEmail(ALICE.getEmail().value).withPhone(ALICE.getPhone().value)
-                .withSurvey(ALICE.getSurvey().survey).build();
+                .withSurveys(ALICE.getSurveys()).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
         // same name, phone and email, different survey -> returns false

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -34,7 +34,9 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_BIRTHDATE = BENSON.getBirthdate().toString();
     private static final String VALID_RACE = BENSON.getRace().toString();
     private static final String VALID_RELIGION = BENSON.getReligion().toString();
-    private static final String VALID_SURVEY = BENSON.getSurvey().toString();
+    private static final List<JsonAdaptedSurvey> VALID_SURVEY = BENSON.getSurveys().stream()
+            .map(JsonAdaptedSurvey::new)
+            .collect(Collectors.toList());
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -40,7 +40,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setBirthdate(person.getBirthdate());
         descriptor.setRace(person.getRace());
         descriptor.setReligion(person.getReligion());
-        descriptor.setSurvey(person.getSurvey());
+        descriptor.setSurveys(person.getSurveys());
         descriptor.setTags(person.getTags());
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -39,7 +39,7 @@ public class PersonBuilder {
     private Birthdate birthdate;
     private Race race;
     private Religion religion;
-    private Survey survey;
+    private Set<Survey> surveys;
     private Set<Tag> tags;
 
     /**
@@ -54,7 +54,7 @@ public class PersonBuilder {
         birthdate = new Birthdate(DEFAULT_BIRTHDATE);
         race = new Race(DEFAULT_RACE);
         religion = new Religion(DEFAULT_RELIGION);
-        survey = new Survey(DEFAULT_SURVEY);
+        surveys = new HashSet<>();
         tags = new HashSet<>();
     }
 
@@ -70,7 +70,7 @@ public class PersonBuilder {
         birthdate = personToCopy.getBirthdate();
         race = personToCopy.getRace();
         religion = personToCopy.getReligion();
-        survey = personToCopy.getSurvey();
+        surveys = new HashSet<>(personToCopy.getSurveys());
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -150,7 +150,9 @@ public class PersonBuilder {
      * Sets the {@code Survey} of the {@code Person} that we are building.
      */
     public PersonBuilder withSurvey(String survey) {
-        this.survey = new Survey(survey);
+        Set<Survey> surveyToAdd = new HashSet<>();
+        surveyToAdd.add(new Survey(survey));
+        this.surveys = surveyToAdd;
         return this;
     }
 
@@ -160,7 +162,7 @@ public class PersonBuilder {
      */
     public Person build() {
         return new Person(name, phone, email, address, gender,
-                birthdate, race, religion, survey, tags);
+                birthdate, race, religion, surveys, tags);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -55,6 +55,7 @@ public class PersonBuilder {
         race = new Race(DEFAULT_RACE);
         religion = new Religion(DEFAULT_RELIGION);
         surveys = new HashSet<>();
+        surveys.add(new Survey(DEFAULT_SURVEY));
         tags = new HashSet<>();
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -156,6 +156,11 @@ public class PersonBuilder {
         return this;
     }
 
+    public PersonBuilder withSurveys(Set<Survey> surveys) {
+        this.surveys = surveys;
+        return this;
+    }
+
     /**
      * Builds a new Person with default parameters or given parameters.
      * @return a Person with stated parameters

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -156,6 +156,9 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Set<Survey>} of the {@code Person} that we are building.
+     */
     public PersonBuilder withSurveys(Set<Survey> surveys) {
         this.surveys = surveys;
         return this;

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -46,7 +46,9 @@ public class PersonUtil {
                 + person.getBirthdate().birthdate.format(DateTimeFormatter.ofPattern(DATE_FORMAT)) + " ");
         sb.append(PREFIX_RACE + person.getRace().race + " ");
         sb.append(PREFIX_RELIGION + person.getReligion().religion + " ");
-        sb.append(PREFIX_SURVEY + person.getSurvey().survey + " ");
+        person.getSurveys().stream().forEach(
+                s -> sb.append(PREFIX_SURVEY + s.survey + " ")
+        );
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );


### PR DESCRIPTION
Resolves #99. There were a lot more changes than I foresaw. I have changed some of the behaviour for the following commands:

- `add` now parses all `s/` prefixes.
```
add n/John Doe ... s/Survey A s/Survey B
> New person added: John Doe ... Surveys: [Survey A][Survey B]
 ```
- `view s/<KEYWORD>` no longer lists persons whose surveys contain the word `<KEYWORD>`. Instead, it lists person who has `<KEYWORD>` as a survey name. This may be improved in #107.
```
view s/Academic
> 0 persons listed!

view s/Academic Survey
> 1 persons listed!
> John Doe ... Surveys: [Academic Survey][Environment Survey]
```
- `delete s/<survey name>` now deletes persons whose surveys contain `<survey name>`, even if they contain other surveys. This is perhaps undesirable; we may want to remove the specified survey from the person rather than deleting the person altogether. Thoughts @deepimpactmir?
```
view s/Academic Survey
> 1 persons listed!
> John Doe ... Surveys: [Academic Survey][Environment Survey]

delete s/Academic Survey
> Deleted person [John Doe ... Surveys: [Academic Survey][Environment Survey]]
```
- `clone` should work as per usual

Please help test your commands! There may be other cases that messes up when multiple surveys are involved, but these are the ones I found.

Also changed the Ui to show multiple surveys, similar to `tags`.