### PR TITLE
Add toggleable theme button and ability to swap between compacted and expanded PersonCards

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ checkstyle {
     toolVersion = '10.2'
 }
 
+run {
+    enableAssertions = true
+}
+
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -93,26 +93,16 @@ public class HelpWindow extends UiPart<Stage> {
      * Set theme of help window to the light theme.
      */
     public void setLightTheme() {
-        boolean hasLightTheme = getRoot().getScene().getStylesheets().contains(lightTheme);
-        boolean hasDarkTheme = getRoot().getScene().getStylesheets().contains(darkTheme);
-
-        if (!hasLightTheme && hasDarkTheme) {
-            getRoot().getScene().getStylesheets().remove(darkTheme);
-            getRoot().getScene().getStylesheets().add(lightTheme);
-        }
+        getRoot().getScene().getStylesheets().add(lightTheme);
+        getRoot().getScene().getStylesheets().remove(darkTheme);
     }
 
     /**
      * Set theme of help window to the dark theme.
      */
     public void setDarkTheme() {
-        boolean hasLightTheme = getRoot().getScene().getStylesheets().contains(lightTheme);
-        boolean hasDarkTheme = getRoot().getScene().getStylesheets().contains(darkTheme);
-
-        if (!hasDarkTheme && hasLightTheme) {
-            getRoot().getScene().getStylesheets().remove(lightTheme);
-            getRoot().getScene().getStylesheets().add(darkTheme);
-        }
+        getRoot().getScene().getStylesheets().add(darkTheme);
+        getRoot().getScene().getStylesheets().remove(lightTheme);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -186,7 +186,7 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
-     * Changes theme to light theme
+     * Changes theme to light theme or dark theme depending on current state.
      */
     @FXML
     private void handleLightDarkTheme() {
@@ -211,6 +211,10 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
+    /**
+     * Compacts or expands all PersonCard depending on current state.
+     * Any new PersonCard will be created compacted or expanded depending on the new state.
+     */
     @FXML
     private void handleCompactExpand() {
         if (isExpanded) {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -24,6 +24,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class MainWindow extends UiPart<Stage> {
 
     private static final String FXML = "MainWindow.fxml";
+    private static final String COMPACT_MENUITEM_TEXT = "Compacted Cards";
+    private static final String EXPAND_MENUITEM_TEXT = "Expanded Cards";
     private static final String LIGHT_THEME_MENUITEM_TEXT = "Light Theme";
     private static final String DARK_THEME_MENUITEM_TEXT = "Dark Theme";
 
@@ -41,6 +43,7 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
+    private boolean isExpanded;
     private boolean isLightTheme;
 
     @FXML
@@ -48,6 +51,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private MenuItem lightDarkThemeItem;
+
+    @FXML
+    private MenuItem compactExpandItem;
 
     @FXML
     private MenuItem helpMenuItem;
@@ -78,6 +84,8 @@ public class MainWindow extends UiPart<Stage> {
 
         helpWindow = new HelpWindow();
 
+        isExpanded = false;
+        compactExpandItem.setText(EXPAND_MENUITEM_TEXT);
         isLightTheme = true;
         lightDarkThemeItem.setText(DARK_THEME_MENUITEM_TEXT);
     }
@@ -124,7 +132,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList(), isExpanded);
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
@@ -201,6 +209,22 @@ public class MainWindow extends UiPart<Stage> {
             primaryStage.getScene().getStylesheets().remove(extensionsDark);
             helpWindow.setLightTheme();
         }
+    }
+
+    @FXML
+    private void handleCompactExpand() {
+        if (isExpanded) {
+            logger.info("Switching to compacted cards...");
+            isExpanded = false;
+            compactExpandItem.setText(EXPAND_MENUITEM_TEXT);
+        } else {
+            logger.info("Switching to expanded cards...");
+            isExpanded = true;
+            compactExpandItem.setText(COMPACT_MENUITEM_TEXT);
+        }
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList(), isExpanded);
+        personListPanelPlaceholder.getChildren().clear();
+        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
     }
 
     public PersonListPanel getPersonListPanel() {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -24,6 +24,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class MainWindow extends UiPart<Stage> {
 
     private static final String FXML = "MainWindow.fxml";
+    private static final String LIGHT_THEME_MENUITEM_TEXT = "Light Theme";
+    private static final String DARK_THEME_MENUITEM_TEXT = "Dark Theme";
 
     private final String lightTheme = getClass().getResource("/view/LightTheme.css").toExternalForm();
     private final String darkTheme = getClass().getResource("/view/DarkTheme.css").toExternalForm();
@@ -39,8 +41,13 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
+    private boolean isLightTheme;
+
     @FXML
     private StackPane commandBoxPlaceholder;
+
+    @FXML
+    private MenuItem lightDarkThemeItem;
 
     @FXML
     private MenuItem helpMenuItem;
@@ -70,6 +77,9 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerators();
 
         helpWindow = new HelpWindow();
+
+        isLightTheme = true;
+        lightDarkThemeItem.setText(DARK_THEME_MENUITEM_TEXT);
     }
 
     public Stage getPrimaryStage() {
@@ -171,34 +181,26 @@ public class MainWindow extends UiPart<Stage> {
      * Changes theme to light theme
      */
     @FXML
-    private void handleLightTheme() {
-        boolean hasLightTheme = primaryStage.getScene().getStylesheets().contains(lightTheme);
-        boolean hasDarkTheme = primaryStage.getScene().getStylesheets().contains(darkTheme);
-
-        if (!hasLightTheme && hasDarkTheme) {
-            primaryStage.getScene().getStylesheets().remove(darkTheme);
-            primaryStage.getScene().getStylesheets().add(lightTheme);
-            primaryStage.getScene().getStylesheets().remove(extensionsDark);
-            primaryStage.getScene().getStylesheets().add(extensionsLight);
-        }
-        helpWindow.setLightTheme();
-    }
-
-    /**
-     * Changes theme to dark theme
-     */
-    @FXML
-    private void handleDarkTheme() {
-        boolean hasLightTheme = primaryStage.getScene().getStylesheets().contains(lightTheme);
-        boolean hasDarkTheme = primaryStage.getScene().getStylesheets().contains(darkTheme);
-
-        if (!hasDarkTheme && hasLightTheme) {
-            primaryStage.getScene().getStylesheets().remove(lightTheme);
+    private void handleLightDarkTheme() {
+        if (isLightTheme) {
+            logger.info("Switching to dark theme...");
+            isLightTheme = false;
+            lightDarkThemeItem.setText(LIGHT_THEME_MENUITEM_TEXT);
             primaryStage.getScene().getStylesheets().add(darkTheme);
-            primaryStage.getScene().getStylesheets().remove(extensionsLight);
             primaryStage.getScene().getStylesheets().add(extensionsDark);
+            primaryStage.getScene().getStylesheets().remove(lightTheme);
+            primaryStage.getScene().getStylesheets().remove(extensionsLight);
+            helpWindow.setDarkTheme();
+        } else {
+            logger.info("Switching to light theme...");
+            isLightTheme = true;
+            lightDarkThemeItem.setText(DARK_THEME_MENUITEM_TEXT);
+            primaryStage.getScene().getStylesheets().add(lightTheme);
+            primaryStage.getScene().getStylesheets().add(extensionsLight);
+            primaryStage.getScene().getStylesheets().remove(darkTheme);
+            primaryStage.getScene().getStylesheets().remove(extensionsDark);
+            helpWindow.setLightTheme();
         }
-        helpWindow.setDarkTheme();
     }
 
     public PersonListPanel getPersonListPanel() {

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -59,11 +59,15 @@ public class PersonCard extends UiPart<Region> {
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
-    public PersonCard(Person person, int displayedIndex) {
+    public PersonCard(Person person, int displayedIndex, boolean isExpanded) {
         super(FXML);
         this.person = person;
-        isExpanded = false;
-        hideLabels();
+        this.isExpanded = isExpanded;
+        if (this.isExpanded) {
+            showLabels();
+        } else {
+            hideLabels();
+        }
 
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -16,6 +16,7 @@ import seedu.address.model.person.Person;
 public class PersonListPanel extends UiPart<Region> {
     private static final String FXML = "PersonListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
+    private final boolean isExpanded;
 
     @FXML
     private ListView<Person> personListView;
@@ -23,10 +24,11 @@ public class PersonListPanel extends UiPart<Region> {
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
-    public PersonListPanel(ObservableList<Person> personList) {
+    public PersonListPanel(ObservableList<Person> personList, boolean isExpanded) {
         super(FXML);
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
+        this.isExpanded = isExpanded;
     }
 
     /**
@@ -43,7 +45,7 @@ public class PersonListPanel extends UiPart<Region> {
                 setText(null);
             } else {
                 if (!person.equals(oldPerson)) {
-                    setGraphic(new PersonCard(person, getIndex() + 1).getRoot());
+                    setGraphic(new PersonCard(person, getIndex() + 1, isExpanded).getRoot());
                 }
             }
         }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -27,9 +27,8 @@
           <Menu mnemonicParsing="false" text="File">
             <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
           </Menu>
-          <Menu mnemonicParsing="false" text="Theme">
-            <MenuItem fx:id="lightThemeItem" mnemonicParsing="false" onAction="#handleLightTheme" text="Light Theme"/>
-            <MenuItem fx:id="darkThemeItem" mnemonicParsing="false" onAction="#handleDarkTheme" text="Dark Theme"/>
+          <Menu mnemonicParsing="false" text="Appearance">
+            <MenuItem fx:id="lightDarkThemeItem" mnemonicParsing="false" onAction="#handleLightDarkTheme" text="Light/Dark Theme"/>
           </Menu>
           <Menu mnemonicParsing="false" text="Help">
             <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -29,6 +29,7 @@
           </Menu>
           <Menu mnemonicParsing="false" text="Appearance">
             <MenuItem fx:id="lightDarkThemeItem" mnemonicParsing="false" onAction="#handleLightDarkTheme" text="Light/Dark Theme"/>
+            <MenuItem fx:id="compactExpandItem" mnemonicParsing="false" onAction="#handleCompactExpand" text="Compacted/Expanded Cards"/>
           </Menu>
           <Menu mnemonicParsing="false" text="Help">
             <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />


### PR DESCRIPTION
Fixes #118 and fixes #119.

Added 2 new buttons under the Appearance tab and removed Theme tab.
1. Button that toggles between light theme and dark theme
2. Button that toggles between compacted and expanded PersonCards. If in compact mode, all cards are by default in their compact mode and vice versa.

![image](https://user-images.githubusercontent.com/92256191/196452715-371b0b0f-5dcb-486d-ba64-adaa013c12ad.png)