### PR TITLE
Improve clone command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -153,17 +153,21 @@ Example:
 
 ### Clone a person : `clone`
 
-Clones a specified person in the app.
+Clones an existing person in Survin with updated details.
 
-Format: `clone INDEX`
+Format: `clone INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [g/GENDER] [b/BIRTHDATE] [ra/RACE] [re/RELIGION] [s/SURVEY] [t/TAG]…`
 
-- Clones the person at the specified `INDEX`.
-- The index refers to the index number shown in the displayed person list.
-- The index **must be a positive integer** 1, 2, 3, …​
+- Clones the surveyee at the specified INDEX. The index refers to the index number of the surveyee you wish to clone, as shown in the display list. The index must be a **positive integer**.
+- At least one of the unique optional fields has to be provided. (E.g. Phone or Email)
+- A new person with updated values in specified field will be added to the address book.
+- When updating tags or surveys, the existing tags or surveys of the person will be removed i.e adding of tags is not cumulative.
+- You can remove all the person’s tags by typing `t/` without specifying any tags after it.
+- You can remove all the person’s surveys by typing `s/` without specifying any surveys after it.
 
 Examples:
 
-* Use `find Alex` to list all the persons whose name contains Alex, followed by `clone 1` to clone the first person in the result and finally use edit command to edit the data of the cloned person.
+- `clone 1 p/91234567 e/johndoe@example.com` Add a new person with all details of the 1st person except the phone number and email will be updated to `91234567` and `johndoe@example.com` respectively.
+- `clone 2 n/Betsy Crower t/` Add a new person with all details of the 2nd person except the name will be updated to `Betsy Crower` and all tags are removed.
 
 ### Viewing a person: `view`
 

--- a/src/main/java/seedu/address/logic/commands/CloneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CloneCommand.java
@@ -1,12 +1,14 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
@@ -30,22 +32,39 @@ public class CloneCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Clones the details of the person identified "
             + "by the index number used in the displayed person list. "
-            + "A new person with different name but same details will be added to the address book.\n"
-            + "Parameters: INDEX (must be a positive integer) \n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (the index of the person needs to be exist) "
+            + "[Optional parameters in square brackets] "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_GENDER + "GENDER] "
+            + "[" + PREFIX_BIRTHDATE + "BIRTHDATE] "
+            + "[" + PREFIX_RACE + "RACE] "
+            + "[" + PREFIX_RELIGION + "RELIGION] "
+            + "[" + PREFIX_SURVEY+ "SURVEY] "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_NAME + "John "
+            + PREFIX_PHONE + "91234567 "
+            + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_CLONE_PERSON_SUCCESS = "Cloned Person: %1$s";
-
-    public static final String DUPLICATE_NAME_EXTENSION = " copy";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_CLONED_PERSON = "This person already exists in the address book, try again with different details";
 
     private final Index index;
+    private final ClonePersonDescriptor clonePersonDescriptor;
+
 
     /**
      * @param index of the person in the filtered person list to cloned
      */
-    public CloneCommand(Index index) {
+    public CloneCommand(Index index, ClonePersonDescriptor clonePersonDescriptor) {
         requireNonNull(index);
         this.index = index;
+        this.clonePersonDescriptor = new ClonePersonDescriptor(clonePersonDescriptor);
     }
 
     @Override
@@ -58,7 +77,12 @@ public class CloneCommand extends Command {
         }
 
         Person personToClone = lastShownList.get(index.getZeroBased());
-        Person clonedPerson = createClonedPerson(model, personToClone);
+        Person clonedPerson = createClonedPerson(personToClone, clonePersonDescriptor);
+
+        if (!personToClone.isSamePerson(clonedPerson) && model.hasPerson(clonedPerson)) {
+            throw new CommandException(MESSAGE_DUPLICATE_CLONED_PERSON);
+        }
+
         model.addPerson(clonedPerson);
         return new CommandResult(String.format(MESSAGE_CLONE_PERSON_SUCCESS, clonedPerson));
     }
@@ -66,27 +90,22 @@ public class CloneCommand extends Command {
     /**
      * Creates and returns a {@code Person} with the details of {@code personToClone}.
      */
-    private static Person createClonedPerson(Model model, Person personToClone) {
+    private static Person createClonedPerson(Person personToClone, ClonePersonDescriptor clonePersonDescriptor) {
         assert personToClone != null;
 
-        if (!model.hasPerson(personToClone)) {
-            return personToClone;
-        }
+        Name clonedName = clonePersonDescriptor.getName().orElse(personToClone.getName());
+        Phone clonedPhone = clonePersonDescriptor.getPhone().orElse(personToClone.getPhone());
+        Email clonedEmail = clonePersonDescriptor.getEmail().orElse(personToClone.getEmail());
+        Address clonedAddress = clonePersonDescriptor.getAddress().orElse(personToClone.getAddress());
+        Gender clonedGender = clonePersonDescriptor.getGender().orElse(personToClone.getGender());
+        Birthdate clonedBirthdate = clonePersonDescriptor.getBirthdate().orElse(personToClone.getBirthdate());
+        Race clonedRace = clonePersonDescriptor.getRace().orElse(personToClone.getRace());
+        Religion clonedReligion = clonePersonDescriptor.getReligion().orElse(personToClone.getReligion());
+        Survey clonedSurvey = clonePersonDescriptor.getSurvey().orElse(personToClone.getSurvey());
+        Set<Tag> clonedTags = clonePersonDescriptor.getTags().orElse(personToClone.getTags());
 
-        Name updatedName = new Name(personToClone.getName() + DUPLICATE_NAME_EXTENSION);
-        Phone clonedPhone = personToClone.getPhone();
-        Email clonedEmail = personToClone.getEmail();
-        Address clonedAddress = personToClone.getAddress();
-        Gender clonedGender = personToClone.getGender();
-        Birthdate clonedBirthdate = personToClone.getBirthdate();
-        Race clonedRace = personToClone.getRace();
-        Religion clonedReligion = personToClone.getReligion();
-        Survey clonedSurvey = personToClone.getSurvey();
-        Set<Tag> clonedTags = (personToClone.getTags() != null) ? personToClone.getTags() : null;
-
-        Person clonedPerson = new Person(updatedName, clonedPhone, clonedEmail, clonedAddress,
+        return new Person(clonedName, clonedPhone, clonedEmail, clonedAddress,
                 clonedGender, clonedBirthdate, clonedRace, clonedReligion, clonedSurvey, clonedTags);
-        return createClonedPerson(model, clonedPerson);
     }
 
     @Override
@@ -103,6 +122,166 @@ public class CloneCommand extends Command {
 
         // state check
         CloneCommand e = (CloneCommand) other;
-        return index.equals(e.index);
+        return index.equals(e.index)
+                && clonePersonDescriptor.equals(e.clonePersonDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the person with. Each non-empty field value will replace the
+     * corresponding field value of the person.
+     */
+    public static class ClonePersonDescriptor {
+        private Name name;
+        private Phone phone;
+        private Email email;
+        private Address address;
+        private Gender gender;
+        private Birthdate birthdate;
+        private Race race;
+        private Religion religion;
+        private Survey survey;
+        private Set<Tag> tags;
+
+        public ClonePersonDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public ClonePersonDescriptor(CloneCommand.ClonePersonDescriptor toCopy) {
+            setName(toCopy.name);
+            setPhone(toCopy.phone);
+            setEmail(toCopy.email);
+            setAddress(toCopy.address);
+            setGender(toCopy.gender);
+            setBirthdate(toCopy.birthdate);
+            setRace(toCopy.race);
+            setReligion(toCopy.religion);
+            setSurvey(toCopy.survey);
+            setTags(toCopy.tags);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, gender, birthdate, race, religion, survey, tags);
+        }
+
+        public void setName(Name name) {
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setPhone(Phone phone) {
+            this.phone = phone;
+        }
+
+        public Optional<Phone> getPhone() {
+            return Optional.ofNullable(phone);
+        }
+
+        public void setEmail(Email email) {
+            this.email = email;
+        }
+
+        public Optional<Email> getEmail() {
+            return Optional.ofNullable(email);
+        }
+
+        public void setAddress(Address address) {
+            this.address = address;
+        }
+
+        public Optional<Address> getAddress() {
+            return Optional.ofNullable(address);
+        }
+
+        public void setGender(Gender gender) {
+            this.gender = gender;
+        }
+
+        public Optional<Gender> getGender() {
+            return Optional.ofNullable(gender);
+        }
+
+        public void setBirthdate(Birthdate birthdate) {
+            this.birthdate = birthdate;
+        }
+
+        public Optional<Birthdate> getBirthdate() {
+            return Optional.ofNullable(birthdate);
+        }
+
+        public void setRace(Race race) {
+            this.race = race;
+        }
+
+        public Optional<Race> getRace() {
+            return Optional.ofNullable(race);
+        }
+
+        public void setReligion(Religion religion) {
+            this.religion = religion;
+        }
+
+        public Optional<Religion> getReligion() {
+            return Optional.ofNullable(religion);
+        }
+
+        public void setSurvey(Survey survey) {
+            this.survey = survey;
+        }
+
+        public Optional<Survey> getSurvey() {
+            return Optional.ofNullable(survey);
+        }
+
+        /**
+         * Sets {@code tags} to this object's {@code tags}.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public void setTags(Set<Tag> tags) {
+            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        }
+
+        /**
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code tags} is null.
+         */
+        public Optional<Set<Tag>> getTags() {
+            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof CloneCommand.ClonePersonDescriptor)) {
+                return false;
+            }
+
+            // state check
+            CloneCommand.ClonePersonDescriptor e = (CloneCommand.ClonePersonDescriptor) other;
+
+            return getName().equals(e.getName())
+                    && getPhone().equals(e.getPhone())
+                    && getEmail().equals(e.getEmail())
+                    && getAddress().equals(e.getAddress())
+                    && getGender().equals(e.getGender())
+                    && getBirthdate().equals(e.getBirthdate())
+                    && getRace().equals(e.getRace())
+                    && getReligion().equals(e.getReligion())
+                    && getSurvey().equals(e.getSurvey())
+                    && getTags().equals(e.getTags());
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/commands/CloneCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CloneCommand.java
@@ -1,12 +1,26 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GENDER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RACE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RELIGION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SURVEY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
@@ -30,22 +44,40 @@ public class CloneCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Clones the details of the person identified "
             + "by the index number used in the displayed person list. "
-            + "A new person with different name but same details will be added to the address book.\n"
-            + "Parameters: INDEX (must be a positive integer) \n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (the index of the person needs to be exist) "
+            + "[Optional parameters in square brackets] "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_GENDER + "GENDER] "
+            + "[" + PREFIX_BIRTHDATE + "BIRTHDATE] "
+            + "[" + PREFIX_RACE + "RACE] "
+            + "[" + PREFIX_RELIGION + "RELIGION] "
+            + "[" + PREFIX_SURVEY + "SURVEY] "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_NAME + "John "
+            + PREFIX_PHONE + "91234567 "
+            + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_CLONE_PERSON_SUCCESS = "Cloned Person: %1$s";
-
-    public static final String DUPLICATE_NAME_EXTENSION = " copy";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_CLONED_PERSON = "This person already exists in the address book, "
+            + "try again with different details.";
 
     private final Index index;
+    private final ClonePersonDescriptor clonePersonDescriptor;
+
 
     /**
      * @param index of the person in the filtered person list to cloned
      */
-    public CloneCommand(Index index) {
+    public CloneCommand(Index index, ClonePersonDescriptor clonePersonDescriptor) {
         requireNonNull(index);
         this.index = index;
+        this.clonePersonDescriptor = new ClonePersonDescriptor(clonePersonDescriptor);
     }
 
     @Override
@@ -58,36 +90,36 @@ public class CloneCommand extends Command {
         }
 
         Person personToClone = lastShownList.get(index.getZeroBased());
-        Person clonedPerson = createClonedPerson(model, personToClone);
+        Person clonedPerson = createClonedPerson(personToClone, clonePersonDescriptor);
+
+        if (!personToClone.isSamePerson(clonedPerson) && model.hasPerson(clonedPerson)) {
+            throw new CommandException(MESSAGE_DUPLICATE_CLONED_PERSON);
+        }
+
         model.addPerson(clonedPerson);
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_CLONE_PERSON_SUCCESS, clonedPerson));
     }
 
     /**
      * Creates and returns a {@code Person} with the details of {@code personToClone}.
      */
-    private static Person createClonedPerson(Model model, Person personToClone) {
+    private static Person createClonedPerson(Person personToClone, ClonePersonDescriptor clonePersonDescriptor) {
         assert personToClone != null;
 
-        if (!model.hasPerson(personToClone)) {
-            return personToClone;
-        }
+        Name clonedName = clonePersonDescriptor.getName().orElse(personToClone.getName());
+        Phone clonedPhone = clonePersonDescriptor.getPhone().orElse(personToClone.getPhone());
+        Email clonedEmail = clonePersonDescriptor.getEmail().orElse(personToClone.getEmail());
+        Address clonedAddress = clonePersonDescriptor.getAddress().orElse(personToClone.getAddress());
+        Gender clonedGender = clonePersonDescriptor.getGender().orElse(personToClone.getGender());
+        Birthdate clonedBirthdate = clonePersonDescriptor.getBirthdate().orElse(personToClone.getBirthdate());
+        Race clonedRace = clonePersonDescriptor.getRace().orElse(personToClone.getRace());
+        Religion clonedReligion = clonePersonDescriptor.getReligion().orElse(personToClone.getReligion());
+        Set<Survey> clonedSurveys = clonePersonDescriptor.getSurveys().orElse(personToClone.getSurveys());
+        Set<Tag> clonedTags = clonePersonDescriptor.getTags().orElse(personToClone.getTags());
 
-        Name updatedName = new Name(personToClone.getName() + DUPLICATE_NAME_EXTENSION);
-        Phone clonedPhone = personToClone.getPhone();
-        Email clonedEmail = personToClone.getEmail();
-        Address clonedAddress = personToClone.getAddress();
-        Gender clonedGender = personToClone.getGender();
-        Birthdate clonedBirthdate = personToClone.getBirthdate();
-        Race clonedRace = personToClone.getRace();
-        Religion clonedReligion = personToClone.getReligion();
-
-        Set<Survey> clonedSurvey = (personToClone.getSurveys() != null) ? personToClone.getSurveys() : null;
-        Set<Tag> clonedTags = (personToClone.getTags() != null) ? personToClone.getTags() : null;
-
-        Person clonedPerson = new Person(updatedName, clonedPhone, clonedEmail, clonedAddress,
-                clonedGender, clonedBirthdate, clonedRace, clonedReligion, clonedSurvey, clonedTags);
-        return createClonedPerson(model, clonedPerson);
+        return new Person(clonedName, clonedPhone, clonedEmail, clonedAddress,
+                clonedGender, clonedBirthdate, clonedRace, clonedReligion, clonedSurveys, clonedTags);
     }
 
     @Override
@@ -104,6 +136,167 @@ public class CloneCommand extends Command {
 
         // state check
         CloneCommand e = (CloneCommand) other;
-        return index.equals(e.index);
+        return index.equals(e.index)
+                && clonePersonDescriptor.equals(e.clonePersonDescriptor);
+    }
+
+    /**
+     * Stores the details to clone the person with. Each non-empty field value will replace the
+     * corresponding field value of the person.
+     */
+    public static class ClonePersonDescriptor {
+        private Name name;
+        private Phone phone;
+        private Email email;
+        private Address address;
+        private Gender gender;
+        private Birthdate birthdate;
+        private Race race;
+        private Religion religion;
+        private Set<Survey> surveys;
+        private Set<Tag> tags;
+
+        public ClonePersonDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public ClonePersonDescriptor(CloneCommand.ClonePersonDescriptor toCopy) {
+            setName(toCopy.name);
+            setPhone(toCopy.phone);
+            setEmail(toCopy.email);
+            setAddress(toCopy.address);
+            setGender(toCopy.gender);
+            setBirthdate(toCopy.birthdate);
+            setRace(toCopy.race);
+            setReligion(toCopy.religion);
+            setSurveys(toCopy.surveys);
+            setTags(toCopy.tags);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, gender, birthdate,
+                    race, religion, surveys, tags);
+        }
+
+        public void setName(Name name) {
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setPhone(Phone phone) {
+            this.phone = phone;
+        }
+
+        public Optional<Phone> getPhone() {
+            return Optional.ofNullable(phone);
+        }
+
+        public void setEmail(Email email) {
+            this.email = email;
+        }
+
+        public Optional<Email> getEmail() {
+            return Optional.ofNullable(email);
+        }
+
+        public void setAddress(Address address) {
+            this.address = address;
+        }
+
+        public Optional<Address> getAddress() {
+            return Optional.ofNullable(address);
+        }
+
+        public void setGender(Gender gender) {
+            this.gender = gender;
+        }
+
+        public Optional<Gender> getGender() {
+            return Optional.ofNullable(gender);
+        }
+
+        public void setBirthdate(Birthdate birthdate) {
+            this.birthdate = birthdate;
+        }
+
+        public Optional<Birthdate> getBirthdate() {
+            return Optional.ofNullable(birthdate);
+        }
+
+        public void setRace(Race race) {
+            this.race = race;
+        }
+
+        public Optional<Race> getRace() {
+            return Optional.ofNullable(race);
+        }
+
+        public void setReligion(Religion religion) {
+            this.religion = religion;
+        }
+
+        public Optional<Religion> getReligion() {
+            return Optional.ofNullable(religion);
+        }
+
+        public void setSurveys(Set<Survey> surveys) {
+            this.surveys = (surveys != null) ? new HashSet<>(surveys) : null;
+        }
+
+        public Optional<Set<Survey>> getSurveys() {
+            return (surveys != null) ? Optional.of(Collections.unmodifiableSet(surveys)) : Optional.empty();
+        }
+
+        /**
+         * Sets {@code tags} to this object's {@code tags}.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public void setTags(Set<Tag> tags) {
+            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        }
+
+        /**
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code tags} is null.
+         */
+        public Optional<Set<Tag>> getTags() {
+            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof CloneCommand.ClonePersonDescriptor)) {
+                return false;
+            }
+
+            // state check
+            CloneCommand.ClonePersonDescriptor e = (CloneCommand.ClonePersonDescriptor) other;
+
+            return getName().equals(e.getName())
+                    && getPhone().equals(e.getPhone())
+                    && getEmail().equals(e.getEmail())
+                    && getAddress().equals(e.getAddress())
+                    && getGender().equals(e.getGender())
+                    && getBirthdate().equals(e.getBirthdate())
+                    && getRace().equals(e.getRace())
+                    && getReligion().equals(e.getReligion())
+                    && getSurveys().equals(e.getSurveys())
+                    && getTags().equals(e.getTags());
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/CloneCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CloneCommandParser.java
@@ -2,10 +2,29 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GENDER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RACE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_RELIGION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SURVEY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CloneCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Survey;
+import seedu.address.model.tag.Tag;
+
+
 
 /**
  * Parses input arguments and creates a new CloneCommand object
@@ -14,17 +33,86 @@ public class CloneCommandParser implements Parser<CloneCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the CloneCommand
-     * and returns a CloneCommand object for execution.
+     * and returns an CloneCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public CloneCommand parse(String args) throws ParseException {
         requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_GENDER, PREFIX_BIRTHDATE, PREFIX_RACE, PREFIX_RELIGION, PREFIX_SURVEY, PREFIX_TAG);
+
+        Index index;
+
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new CloneCommand(index);
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CloneCommand.MESSAGE_USAGE), pe);
         }
 
+        CloneCommand.ClonePersonDescriptor clonePersonDescriptor = new CloneCommand.ClonePersonDescriptor();
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            clonePersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            clonePersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            clonePersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+        }
+        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
+            clonePersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_GENDER).isPresent()) {
+            clonePersonDescriptor.setGender(ParserUtil.parseGender(argMultimap.getValue(PREFIX_GENDER).get()));
+        }
+        if (argMultimap.getValue(PREFIX_BIRTHDATE).isPresent()) {
+            clonePersonDescriptor.setBirthdate(ParserUtil.parseBirthdate(argMultimap.getValue(PREFIX_BIRTHDATE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_RACE).isPresent()) {
+            clonePersonDescriptor.setRace(ParserUtil.parseRace(argMultimap.getValue(PREFIX_RACE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_RELIGION).isPresent()) {
+            clonePersonDescriptor.setReligion(ParserUtil.parseReligion(argMultimap.getValue(PREFIX_RELIGION).get()));
+        }
+        parseSurveysForClone(argMultimap.getAllValues(PREFIX_SURVEY)).ifPresent(clonePersonDescriptor::setSurveys);
+        parseTagsForClone(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(clonePersonDescriptor::setTags);
+
+        if (!clonePersonDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(CloneCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new CloneCommand(index, clonePersonDescriptor);
     }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    private Optional<Set<Tag>> parseTagsForClone(Collection<String> tags) throws ParseException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(ParserUtil.parseTags(tagSet));
+    }
+
+    /**
+     * Parses {@code Collection<String> surveys} into a {@code Set<Survey>} if {@code surveys} is non-empty.
+     * If {@code surveys} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Survey>} containing zero surveys.
+     */
+    private Optional<Set<Survey>> parseSurveysForClone(Collection<String> surveys) throws ParseException {
+        assert surveys != null;
+
+        if (surveys.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> surveySet = surveys.size() == 1 && surveys.contains("") ? Collections.emptySet() : surveys;
+        return Optional.of(ParserUtil.parseSurveys(surveySet));
+    }
+
 }

--- a/src/main/java/seedu/address/logic/parser/CloneCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CloneCommandParser.java
@@ -2,10 +2,18 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CloneCommand;
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Parses input arguments and creates a new CloneCommand object
@@ -14,17 +22,73 @@ public class CloneCommandParser implements Parser<CloneCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the CloneCommand
-     * and returns a CloneCommand object for execution.
+     * and returns an CloneCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public CloneCommand parse(String args) throws ParseException {
         requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_GENDER, PREFIX_BIRTHDATE, PREFIX_RACE, PREFIX_RELIGION, PREFIX_SURVEY, PREFIX_TAG);
+
+        Index index;
+
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new CloneCommand(index);
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CloneCommand.MESSAGE_USAGE), pe);
         }
 
+        CloneCommand.ClonePersonDescriptor clonePersonDescriptor = new CloneCommand.ClonePersonDescriptor();
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            clonePersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            clonePersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            clonePersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+        }
+        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
+            clonePersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_GENDER).isPresent()) {
+            clonePersonDescriptor.setGender(ParserUtil.parseGender(argMultimap.getValue(PREFIX_GENDER).get()));
+        }
+        if (argMultimap.getValue(PREFIX_BIRTHDATE).isPresent()) {
+            clonePersonDescriptor.setBirthdate(ParserUtil.parseBirthdate(argMultimap.getValue(PREFIX_BIRTHDATE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_RACE).isPresent()) {
+            clonePersonDescriptor.setRace(ParserUtil.parseRace(argMultimap.getValue(PREFIX_RACE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_RELIGION).isPresent()) {
+            clonePersonDescriptor.setReligion(ParserUtil.parseReligion(argMultimap.getValue(PREFIX_RELIGION).get()));
+        }
+        if (argMultimap.getValue(PREFIX_SURVEY).isPresent()) {
+            clonePersonDescriptor.setSurvey(ParserUtil.parseSurvey(argMultimap.getValue(PREFIX_SURVEY).get()));
+        }
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(clonePersonDescriptor::setTags);
+
+        if (!clonePersonDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(CloneCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new CloneCommand(index, clonePersonDescriptor);
     }
+
+    /**
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
+     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero tags.
+     */
+    private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(ParserUtil.parseTags(tagSet));
+    }
+
 }

--- a/src/test/java/seedu/address/logic/commands/CloneCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CloneCommandTest.java
@@ -1,0 +1,161 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.C_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.C_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CloneCommand.ClonePersonDescriptor;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.ClonePersonDescriptorBuilder;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for CloneCommand.
+ */
+public class CloneCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Person clonedPerson = new PersonBuilder().build();
+        ClonePersonDescriptor descriptor = new ClonePersonDescriptorBuilder(clonedPerson).build();
+        CloneCommand cloneCommand = new CloneCommand(INDEX_FIRST_PERSON, descriptor);
+
+        String expectedMessage = String.format(CloneCommand.MESSAGE_CLONE_PERSON_SUCCESS, clonedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.addPerson(clonedPerson);
+        expectedModel.commitAddressBook();
+
+        assertCommandSuccess(cloneCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
+        Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+
+        PersonBuilder personInList = new PersonBuilder(lastPerson);
+        Person clonedPerson = personInList.withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
+                .withTags(VALID_TAG_FRIEND).build();
+
+        ClonePersonDescriptor descriptor = new ClonePersonDescriptorBuilder().withName(VALID_NAME_AMY)
+                .withPhone(VALID_PHONE_AMY).withTags(VALID_TAG_FRIEND).build();
+        CloneCommand cloneCommand = new CloneCommand(indexLastPerson, descriptor);
+
+        String expectedMessage = String.format(CloneCommand.MESSAGE_CLONE_PERSON_SUCCESS, clonedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.addPerson(clonedPerson);
+        expectedModel.commitAddressBook();
+
+        assertCommandSuccess(cloneCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person clonedPerson = new PersonBuilder(personInFilteredList).withName(VALID_NAME_AMY).build();
+        CloneCommand cloneCommand = new CloneCommand(INDEX_FIRST_PERSON,
+                new ClonePersonDescriptorBuilder().withName(VALID_NAME_AMY).build());
+
+        String expectedMessage = String.format(CloneCommand.MESSAGE_CLONE_PERSON_SUCCESS, clonedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.addPerson(clonedPerson);
+        expectedModel.commitAddressBook();
+
+        assertCommandSuccess(cloneCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicatePersonUnfilteredList_failure() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        ClonePersonDescriptor descriptor = new ClonePersonDescriptorBuilder(firstPerson).build();
+        CloneCommand cloneCommand = new CloneCommand(INDEX_SECOND_PERSON, descriptor);
+
+        assertCommandFailure(cloneCommand, model, CloneCommand.MESSAGE_DUPLICATE_CLONED_PERSON);
+    }
+
+    @Test
+    public void execute_duplicatePersonFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        // clone person in filtered list into a duplicate in address book
+        Person personInList = model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        CloneCommand cloneCommand = new CloneCommand(INDEX_FIRST_PERSON,
+                new ClonePersonDescriptorBuilder(personInList).build());
+
+        assertCommandFailure(cloneCommand, model, CloneCommand.MESSAGE_DUPLICATE_CLONED_PERSON);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        ClonePersonDescriptor descriptor = new ClonePersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
+        CloneCommand cloneCommand = new CloneCommand(outOfBoundIndex, descriptor);
+
+        assertCommandFailure(cloneCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        CloneCommand cloneCommand = new CloneCommand(outOfBoundIndex,
+                new ClonePersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
+
+        assertCommandFailure(cloneCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final CloneCommand standardCommand = new CloneCommand(INDEX_FIRST_PERSON, C_DESC_AMY);
+
+        // same values -> returns true
+        ClonePersonDescriptor copyDescriptor = new ClonePersonDescriptor(C_DESC_AMY);
+        CloneCommand commandWithSameValues = new CloneCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new CloneCommand(INDEX_SECOND_PERSON, C_DESC_AMY)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new CloneCommand(INDEX_FIRST_PERSON, C_DESC_BOB)));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/ClonePersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClonePersonDescriptorTest.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.C_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.C_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.CloneCommand.ClonePersonDescriptor;
+import seedu.address.testutil.ClonePersonDescriptorBuilder;
+
+public class ClonePersonDescriptorTest {
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        ClonePersonDescriptor descriptorWithSameValues = new ClonePersonDescriptor(C_DESC_AMY);
+        assertTrue(C_DESC_AMY.equals(descriptorWithSameValues));
+
+        // same object -> returns true
+        assertTrue(C_DESC_AMY.equals(C_DESC_AMY));
+
+        // null -> returns false
+        assertFalse(C_DESC_AMY.equals(null));
+
+        // different types -> returns false
+        assertFalse(C_DESC_AMY.equals(5));
+
+        // different values -> returns false
+        assertFalse(C_DESC_AMY.equals(C_DESC_BOB));
+
+        // different name -> returns false
+        ClonePersonDescriptor clonedAmy = new ClonePersonDescriptorBuilder(C_DESC_AMY).withName(VALID_NAME_BOB).build();
+        assertFalse(C_DESC_AMY.equals(clonedAmy));
+
+        // different phone -> returns false
+        clonedAmy = new ClonePersonDescriptorBuilder(C_DESC_AMY).withPhone(VALID_PHONE_BOB).build();
+        assertFalse(C_DESC_AMY.equals(clonedAmy));
+
+        // different email -> returns false
+        clonedAmy = new ClonePersonDescriptorBuilder(C_DESC_AMY).withEmail(VALID_EMAIL_BOB).build();
+        assertFalse(C_DESC_AMY.equals(clonedAmy));
+
+        // different address -> returns false
+        clonedAmy = new ClonePersonDescriptorBuilder(C_DESC_AMY).withAddress(VALID_ADDRESS_BOB).build();
+        assertFalse(C_DESC_AMY.equals(clonedAmy));
+
+        // different tags -> returns false
+        clonedAmy = new ClonePersonDescriptorBuilder(C_DESC_AMY).withTags(VALID_TAG_HUSBAND).build();
+        assertFalse(C_DESC_AMY.equals(clonedAmy));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -24,6 +24,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.testutil.ClonePersonDescriptorBuilder;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 /**
@@ -85,11 +86,19 @@ public class CommandTestUtil {
 
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
+    public static final CloneCommand.ClonePersonDescriptor C_DESC_AMY;
+    public static final CloneCommand.ClonePersonDescriptor C_DESC_BOB;
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
                 .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
+                .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+                .build();
+
+        C_DESC_AMY = new ClonePersonDescriptorBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
+                .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
+        C_DESC_BOB = new ClonePersonDescriptorBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
                 .build();
     }

--- a/src/test/java/seedu/address/logic/parser/CloneCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CloneCommandParserTest.java
@@ -1,32 +1,224 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SURVEY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CloneCommand;
+import seedu.address.logic.commands.CloneCommand.ClonePersonDescriptor;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.ClonePersonDescriptorBuilder;
 
-/**
- * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
- * same path through the CloneCommand, and therefore we test only one of them.
- * The path variation for those two cases occur inside the ParserUtil, and
- * therefore should be covered by the ParserUtilTest.
- */
 public class CloneCommandParserTest {
+
+    private static final String TAG_EMPTY = " " + PREFIX_TAG;
+    private static final String SURVEY_EMPTY = " " + PREFIX_SURVEY;
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, CloneCommand.MESSAGE_USAGE);
 
     private CloneCommandParser parser = new CloneCommandParser();
 
     @Test
-    public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new CloneCommand(INDEX_FIRST_PERSON));
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(parser, "1", CloneCommand.MESSAGE_NOT_EDITED);
+
+        // no index and no field specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
     }
 
     @Test
-    public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, CloneCommand.MESSAGE_USAGE));
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
+        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
+        assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
+
+        // invalid phone followed by valid email
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+
+        // valid phone followed by invalid phone. The test case for invalid phone followed by valid phone
+        // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
+        assertParseFailure(parser, "1" + PHONE_DESC_BOB + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS);
+
+        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being cloned,
+        // parsing it together with a valid tag results in error
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+
+        // multiple invalid values, but only the first invalid value is captured
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
+                Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
+                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
+
+        ClonePersonDescriptor descriptor = new ClonePersonDescriptorBuilder().withName(VALID_NAME_AMY)
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+        CloneCommand expectedCommand = new CloneCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_someFieldsSpecified_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
+
+        ClonePersonDescriptor descriptor = new ClonePersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
+                .withEmail(VALID_EMAIL_AMY).build();
+        CloneCommand expectedCommand = new CloneCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_oneFieldSpecified_success() {
+        // name
+        Index targetIndex = INDEX_THIRD_PERSON;
+        String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
+        ClonePersonDescriptor descriptor = new ClonePersonDescriptorBuilder().withName(VALID_NAME_AMY).build();
+        CloneCommand expectedCommand = new CloneCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // phone
+        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
+        descriptor = new ClonePersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
+        expectedCommand = new CloneCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // email
+        userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
+        descriptor = new ClonePersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
+        expectedCommand = new CloneCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // address
+        userInput = targetIndex.getOneBased() + ADDRESS_DESC_AMY;
+        descriptor = new ClonePersonDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
+        expectedCommand = new CloneCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // tags
+        userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
+        descriptor = new ClonePersonDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
+        expectedCommand = new CloneCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_acceptsLast() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
+                + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
+                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+
+        ClonePersonDescriptor descriptor = new ClonePersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
+                .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
+                .build();
+        CloneCommand expectedCommand = new CloneCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidValueFollowedByValidValue_success() {
+        // no other valid values specified
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
+        ClonePersonDescriptor descriptor = new ClonePersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
+        CloneCommand expectedCommand = new CloneCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // other valid values specified
+        userInput = targetIndex.getOneBased() + EMAIL_DESC_BOB + INVALID_PHONE_DESC + ADDRESS_DESC_BOB
+                + PHONE_DESC_BOB;
+        descriptor = new ClonePersonDescriptorBuilder().withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+                .withAddress(VALID_ADDRESS_BOB).build();
+        expectedCommand = new CloneCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_resetTags_success() {
+        Index targetIndex = INDEX_THIRD_PERSON;
+        String userInput = targetIndex.getOneBased() + TAG_EMPTY;
+
+        ClonePersonDescriptor descriptor = new ClonePersonDescriptorBuilder().withTags().build();
+        CloneCommand expectedCommand = new CloneCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_resetSurveys_success() {
+        Index targetIndex = INDEX_THIRD_PERSON;
+        String userInput = targetIndex.getOneBased() + SURVEY_EMPTY;
+
+        ClonePersonDescriptor descriptor = new ClonePersonDescriptorBuilder().withSurveys().build();
+        CloneCommand expectedCommand = new CloneCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
     }
 }

--- a/src/test/java/seedu/address/testutil/ClonePersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/ClonePersonDescriptorBuilder.java
@@ -1,0 +1,103 @@
+package seedu.address.testutil;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.CloneCommand.ClonePersonDescriptor;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Survey;
+import seedu.address.model.tag.Tag;
+
+/**
+ * A utility class to help with building ClonePersonDescriptor objects.
+ */
+public class ClonePersonDescriptorBuilder {
+
+    private ClonePersonDescriptor descriptor;
+
+    public ClonePersonDescriptorBuilder() {
+        descriptor = new ClonePersonDescriptor();
+    }
+
+    public ClonePersonDescriptorBuilder(ClonePersonDescriptor descriptor) {
+        this.descriptor = new ClonePersonDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code ClonePersonDescriptor} with fields containing {@code person}'s details
+     */
+    public ClonePersonDescriptorBuilder(Person person) {
+        descriptor = new ClonePersonDescriptor();
+        descriptor.setName(person.getName());
+        descriptor.setPhone(person.getPhone());
+        descriptor.setEmail(person.getEmail());
+        descriptor.setAddress(person.getAddress());
+        descriptor.setGender(person.getGender());
+        descriptor.setBirthdate(person.getBirthdate());
+        descriptor.setRace(person.getRace());
+        descriptor.setReligion(person.getReligion());
+        descriptor.setSurveys(person.getSurveys());
+        descriptor.setTags(person.getTags());
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code ClonePersonDescriptor} that we are building.
+     */
+    public ClonePersonDescriptorBuilder withName(String name) {
+        descriptor.setName(new Name(name));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Phone} of the {@code ClonePersonDescriptor} that we are building.
+     */
+    public ClonePersonDescriptorBuilder withPhone(String phone) {
+        descriptor.setPhone(new Phone(phone));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Email} of the {@code ClonePersonDescriptor} that we are building.
+     */
+    public ClonePersonDescriptorBuilder withEmail(String email) {
+        descriptor.setEmail(new Email(email));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Address} of the {@code ClonePersonDescriptor} that we are building.
+     */
+    public ClonePersonDescriptorBuilder withAddress(String address) {
+        descriptor.setAddress(new Address(address));
+        return this;
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code ClonePersonDescriptor}
+     * that we are building.
+     */
+    public ClonePersonDescriptorBuilder withTags(String... tags) {
+        Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
+        descriptor.setTags(tagSet);
+        return this;
+    }
+
+    /**
+     * Parses the {@code surveys} into a {@code Set<Survey>} and set it to the {@code ClonePersonDescriptor}
+     * that we are building.
+     */
+    public ClonePersonDescriptorBuilder withSurveys(String... surveys) {
+        Set<Survey> surveySet = Stream.of(surveys).map(Survey::new).collect(Collectors.toSet());
+        descriptor.setSurveys(surveySet);
+        return this;
+    }
+
+    public ClonePersonDescriptor build() {
+        return descriptor;
+    }
+}


### PR DESCRIPTION
This PR is for issue [#106](https://github.com/AY2223S1-CS2103-F13-2/tp/issues/106). 

As for now, we can simply use **clone 1 p/91234567 e/johndoe@example.com** to add a new person with all details of the 1st person except the phone number and email will be updated to `91234567` and `johndoe@example.com` respectively.

Other than that, I added in test classes for `cloneCommand` and` CloneCommandParser` and updated the User guide for clone command. Thanks to @KeithPJX's feedback, I also modified the MESSAGE_USAGE in clone command slightly.

Welcome any new suggestions and feedback if you have, Thanks!