### PR TITLE
Improve behaviour of `view`

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -175,6 +175,15 @@ Views the attributes of all surveyees with some specified attributes.
 
 Format: `[n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [g/GENDER] [b/BIRTHDATE] [ra/RACE] [re/RELIGION] [s/NAME OF SURVEY]`
 
+- The search is case-insensitive. e.g `alex` will match `Alex`
+- The order of the keywords does not matter. e.g. `Alex Tan` will match `Tan Alex`
+- For all attributes except `email` and `birthdate`, only full words will be matched e.g. `Ale` will not match `Alex`
+- Use quotes (") to `view` persons whose attributes contain an exact phrase.
+- For phrases not in quotes, `view` lists all persons whose attributes contain any of the words specified.
+    e.g. `view n/Jane Doe "Alex Tan"` lists all persons whose names contain any of the following: `Jane`, `Doe` or `Alex Tan`.
+- When using `view` on an attribute with multiple objects (e.g. `Survey` or `Tag`), `view` performs the search on each object.
+- When using `view` on any attribute, only the last prefix is parsed. e.g. `view ra/chinese ra/malay g/male g/female` lists female malay persons, ignores `ra/chinese` and `g/male`.
+
 <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 Fields must be non-empty.
 </div>
@@ -183,8 +192,9 @@ Examples:
 
 ```
 view g/female ra/chinese re/christian
-> Index: 15 Jane Doe 91234567 jane_doe@example.com, …
-> Index: 19 Jenette Doe 81234567 jenette_doe@example.com, …
+> 2 persons listed!
+> Jane Doe 91234567 jane_doe@example.com, …
+> Jenette Doe 81234567 jenette_doe@example.com, …
 ```
 
 

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -13,20 +13,15 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_SURVEY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.PersonContainsAttributePredicate;
-import seedu.address.model.person.Survey;
-import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -82,16 +77,17 @@ public class ViewCommandParser implements Parser<ViewCommand> {
     }
 
     /**
-     * Parses the given {@code String} of a given prefix.
-     * @return A list of {@code String} of keywords associated to the given prefix, taking into account any quotation
-     * marks used.
+     * Parses the given {@code String} of a given prefix with quotation marks.
+     * @return A list of {@code String} of keywords associated to the given prefix, taking into account
+     *     quotation marks to parse exact phrases.
      */
     //Solution below adapted from https://stackoverflow.com/a/7804472
     private static List<String> parseWithQuotations(String input) {
         ArrayList<String> parsedArray = new ArrayList<>();
         Matcher m = Pattern.compile("\\s*([^\"]\\S*|\".+?\")\\s*").matcher(input);
-        while (m.find())
+        while (m.find()) {
             parsedArray.add(m.group(1).replace("\"", ""));
+        }
         return parsedArray;
     }
 

--- a/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewCommandParser.java
@@ -17,6 +17,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.ViewCommand;
@@ -58,9 +61,8 @@ public class ViewCommandParser implements Parser<ViewCommand> {
         List<String> birthdateList = getKeywordsAsList(argMultimap.getValue(PREFIX_BIRTHDATE));
         List<String> raceList = getKeywordsAsList(argMultimap.getValue(PREFIX_RACE));
         List<String> religionList = getKeywordsAsList(argMultimap.getValue(PREFIX_RELIGION));
-
-        Set<Survey> surveyList = ParserUtil.parseSurveys(argMultimap.getAllValues(PREFIX_SURVEY));
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        List<String> surveyList = getKeywordsAsList(argMultimap.getValue(PREFIX_SURVEY));
+        List<String> tagList = getKeywordsAsList(argMultimap.getValue(PREFIX_TAG));
 
         PersonContainsAttributePredicate predicate = new PersonContainsAttributePredicate(nameList, phoneList,
                 emailList, addressList, genderList, birthdateList, raceList, religionList, surveyList,
@@ -70,14 +72,27 @@ public class ViewCommandParser implements Parser<ViewCommand> {
     }
 
     /**
-     * Parses the given (possibly empty) {@code attributeStringOptional} of a given prefix.
+     * Parses the given (possibly empty) {@code Optional<String>} of a given prefix.
      * @return A list of {@code String} of keywords associated to the given prefix.
      */
     private static List<String> getKeywordsAsList(Optional<String> attributeStringOptional) {
         return attributeStringOptional
-                .map(arg -> arg.trim().split("\\s+"))
-                .map(Arrays::asList)
+                .map(ViewCommandParser::parseWithQuotations)
                 .orElse(new ArrayList<>());
+    }
+
+    /**
+     * Parses the given {@code String} of a given prefix.
+     * @return A list of {@code String} of keywords associated to the given prefix, taking into account any quotation
+     * marks used.
+     */
+    //Solution below adapted from https://stackoverflow.com/a/7804472
+    private static List<String> parseWithQuotations(String input) {
+        ArrayList<String> parsedArray = new ArrayList<>();
+        Matcher m = Pattern.compile("\\s*([^\"]\\S*|\".+?\")\\s*").matcher(input);
+        while (m.find())
+            parsedArray.add(m.group(1).replace("\"", ""));
+        return parsedArray;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/PersonContainsAttributePredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsAttributePredicate.java
@@ -2,10 +2,7 @@ package seedu.address.model.person;
 
 import java.util.Arrays;
 import java.util.List;
-
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
 
 /**
  * Tests that a {@code Person}'s attributes matches any of the keywords given for each attribute.
@@ -86,6 +83,10 @@ public class PersonContainsAttributePredicate implements Predicate<Person> {
                 && containsTags);
     }
 
+    /**
+     * Checks whether a given {@code String} contains a word (case-insensitive).
+     * @return A predicate for whether a string contains a word.
+     */
     public static Predicate<String> containsIgnoreCase(String targetString) {
         return keyword -> Arrays.stream(targetString.split("\\s+"))
                 .anyMatch(targetWord -> targetWord.equalsIgnoreCase(keyword));

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -34,13 +34,13 @@ public class ViewCommandTest {
         PersonContainsAttributePredicate firstPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("male"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
-                        new HashSet<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>());
         PersonContainsAttributePredicate secondPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("female"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
-                        new HashSet<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>());
 
         ViewCommand viewFirstCommand = new ViewCommand(firstPredicate);
         ViewCommand viewSecondCommand = new ViewCommand(secondPredicate);
@@ -70,8 +70,8 @@ public class ViewCommandTest {
         PersonContainsAttributePredicate testPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("r4nd0m_inV4l1d_g3nd3r"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
-                        new HashSet<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>());
         ViewCommand command = new ViewCommand(testPredicate);
         expectedModel.updateFilteredPersonList(testPredicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -84,8 +84,8 @@ public class ViewCommandTest {
         PersonContainsAttributePredicate testPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("female"), new ArrayList<>(),
-                        new ArrayList<>(), List.of("christian"), new HashSet<>(),
-                        new HashSet<>());
+                        new ArrayList<>(), List.of("christian"), new ArrayList<>(),
+                        new ArrayList<>());
         ViewCommand command = new ViewCommand(testPredicate);
         expectedModel.updateFilteredPersonList(testPredicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCommandTest.java
@@ -12,7 +12,6 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewCommandParserTest.java
@@ -36,8 +36,8 @@ public class ViewCommandParserTest {
         PersonContainsAttributePredicate testPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("male"), new ArrayList<>(),
-                        List.of("chinese"), new ArrayList<>(), new HashSet<>(),
-                        new HashSet<>());
+                        List.of("chinese"), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>());
         ViewCommand expectedViewCommand = new ViewCommand(testPredicate);
 
         assertParseSuccess(parser, " g/male ra/chinese", expectedViewCommand);

--- a/src/test/java/seedu/address/model/person/PersonContainsAttributePredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsAttributePredicateTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/model/person/PersonContainsAttributePredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsAttributePredicateTest.java
@@ -19,13 +19,13 @@ public class PersonContainsAttributePredicateTest {
         PersonContainsAttributePredicate firstPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("male"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
-                        new HashSet<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>());
         PersonContainsAttributePredicate secondPredicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("female"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
-                        new HashSet<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>());
 
         ViewCommand viewFirstCommand = new ViewCommand(firstPredicate);
         ViewCommand viewSecondCommand = new ViewCommand(secondPredicate);
@@ -54,32 +54,32 @@ public class PersonContainsAttributePredicateTest {
         PersonContainsAttributePredicate predicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("male"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
-                        new HashSet<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>());
         assertTrue(predicate.test(new PersonBuilder().withGender("male").build()));
 
         // Multiple keywords
         predicate =
                 new PersonContainsAttributePredicate(List.of("Alice", "Bob"), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
-                        new HashSet<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>());
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Only one matching keyword
         predicate =
                 new PersonContainsAttributePredicate(List.of("Bob", "Carol"), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
-                        new HashSet<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>());
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
 
         // Mixed-case keywords
         predicate =
                 new PersonContainsAttributePredicate(List.of("aLiCe", "bOb"), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
-                        new HashSet<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>());
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 
@@ -89,8 +89,8 @@ public class PersonContainsAttributePredicateTest {
         PersonContainsAttributePredicate predicate =
                 new PersonContainsAttributePredicate(new ArrayList<>(), new ArrayList<>(),
                         new ArrayList<>(), new ArrayList<>(), List.of("r4nd0m_inV4l1d_g3nd3r"), new ArrayList<>(),
-                        new ArrayList<>(), new ArrayList<>(), new HashSet<>(),
-                        new HashSet<>());
+                        new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                        new ArrayList<>());
         assertFalse(predicate.test(new PersonBuilder().withGender("female").build()));
 
     }


### PR DESCRIPTION
Resolves #107, where `view` now supports searching for exact phrases. Users may use the quotation mark symbol `"` to mark the exact phrase he/she wishes to search.

- The user guide has been updated to fit the new implementation of `view`.
- Refactor JUnit tests for `view`.
- Fix a small issue when using `view \s[survey]` on a person with multiple survey, as briefly discussed in #113.