### PR TITLE
Fix behaviour of `add`

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -50,7 +50,6 @@ public class MainApp extends Application {
     public void init() throws Exception {
         logger.info("=============================[ Initializing AddressBook ]===========================");
         super.init();
-
         AppParameters appParameters = AppParameters.parse(getParameters());
         config = initConfig(appParameters.getConfigPath());
 
@@ -69,9 +68,11 @@ public class MainApp extends Application {
     }
 
     /**
-     * Returns a {@code ModelManager} with the data from {@code storage}'s address book and {@code userPrefs}. <br>
-     * The data from the sample address book will be used instead if {@code storage}'s address book is not found,
-     * or an empty address book will be used instead if errors occur when reading {@code storage}'s address book.
+     * Returns a {@code ModelManager} with the data from {@code storage}'s address
+     * book and {@code userPrefs}. <br>
+     * The data from the sample address book will be used instead if
+     * {@code storage}'s address book is not found, or an empty address book will be
+     * used instead if errors occur when reading {@code storage}'s address book.
      */
     private Model initModelManager(Storage storage, ReadOnlyUserPrefs userPrefs) {
         Optional<ReadOnlyAddressBook> addressBookOptional;
@@ -124,7 +125,8 @@ public class MainApp extends Application {
             initializedConfig = new Config();
         }
 
-        //Update config file in case it was missing to begin with or there are new/unused fields
+        // Update config file in case it was missing to begin with or there are
+        // new/unused fields
         try {
             ConfigUtil.saveConfig(initializedConfig, configFilePathUsed);
         } catch (IOException e) {
@@ -134,9 +136,9 @@ public class MainApp extends Application {
     }
 
     /**
-     * Returns a {@code UserPrefs} using the file at {@code storage}'s user prefs file path,
-     * or a new {@code UserPrefs} with default configuration if errors occur when
-     * reading from the file.
+     * Returns a {@code UserPrefs} using the file at {@code storage}'s user prefs
+     * file path, or a new {@code UserPrefs} with default configuration if errors
+     * occur when reading from the file.
      */
     protected UserPrefs initPrefs(UserPrefsStorage storage) {
         Path prefsFilePath = storage.getUserPrefsFilePath();
@@ -155,7 +157,8 @@ public class MainApp extends Application {
             initializedPrefs = new UserPrefs();
         }
 
-        //Update prefs file in case it was missing to begin with or there are new/unused fields
+        // Update prefs file in case it was missing to begin with or there are
+        // new/unused fields
         try {
             storage.saveUserPrefs(initializedPrefs);
         } catch (IOException e) {

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -12,9 +12,13 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_RELIGION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SURVEY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Survey;
 
 /**
  * Adds a person to the address book.
@@ -49,10 +53,20 @@ public class AddCommand extends Command {
         requireNonNull(model);
 
         if (model.hasPerson(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            Person person = model.getPerson(toAdd).orElseThrow(() -> new CommandException(MESSAGE_DUPLICATE_PERSON));
+            if (person.getSurveys().equals(toAdd.getSurveys())) {
+                throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            }
+            Set<Survey> surveySet = new HashSet<>();
+            surveySet.addAll(person.getSurveys());
+            surveySet.addAll(toAdd.getSurveys());
+            Person newPerson = new Person(toAdd.getName(), toAdd.getPhone(), toAdd.getEmail(), toAdd.getAddress(),
+                    toAdd.getGender(), toAdd.getBirthdate(), toAdd.getRace(), toAdd.getReligion(), surveySet,
+                    toAdd.getTags());
+            model.setPerson(person, newPerson);
+        } else {
+            model.addPerson(toAdd);
         }
-
-        model.addPerson(toAdd);
         model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -39,6 +39,9 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         Pattern pattern = Pattern.compile(REGEX);
         Matcher matcher = pattern.matcher(args.trim());
         if (!matcher.matches()) {
+            if (Character.isDigit(args.trim().charAt(0))) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
             if (argMultimap.getValue(PREFIX_RACE).isPresent()) {
                 race = Optional.of(ParserUtil.parseRace(argMultimap.getValue(PREFIX_RACE).get()));
             }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Optional;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
@@ -67,6 +68,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean hasPerson(Person person) {
         requireNonNull(person);
         return persons.contains(person);
+    }
+
+    public Optional<Person> getPerson(Person person) {
+        requireNonNull(person);
+        return persons.getPerson(person);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -57,6 +58,8 @@ public interface Model {
      * the address book.
      */
     boolean hasPerson(Person person);
+
+    Optional<Person> getPerson(Person person);
 
     /**
      * Deletes the given person. The person must exist in the address book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -93,6 +94,12 @@ public class ModelManager implements Model {
     public boolean hasPerson(Person person) {
         requireNonNull(person);
         return addressBook.hasPerson(person);
+    }
+
+    @Override
+    public Optional<Person> getPerson(Person person) {
+        requireNonNull(person);
+        return addressBook.getPerson(person);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/VersionedAddressBook.java
+++ b/src/main/java/seedu/address/model/VersionedAddressBook.java
@@ -36,7 +36,7 @@ public class VersionedAddressBook extends AddressBook {
     }
 
     /**
-     * Restores address book to a previous state.
+     * Restores address book to a previous state if address book is undoable.
      */
     public void undo() {
         assert canUndo() : "should be undoable";

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -110,8 +110,7 @@ public class Person {
         }
 
         return otherPerson != null && otherPerson.getName().equals(getName())
-                && otherPerson.getPhone().equals(getPhone()) && otherPerson.getEmail().equals(getEmail())
-                && otherPerson.getSurveys().equals(getSurveys());
+                && otherPerson.getPhone().equals(getPhone()) && otherPerson.getEmail().equals(getEmail());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -12,11 +13,13 @@ import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
- * A list of persons that enforces uniqueness between its elements and does not allow nulls.
- * A person is considered unique by comparing using {@code Person#isSamePerson(Person)}. As such, adding and updating of
- * persons uses Person#isSamePerson(Person) for equality so as to ensure that the person being added or updated is
- * unique in terms of identity in the UniquePersonList. However, the removal of a person uses Person#equals(Object) so
- * as to ensure that the person with exactly the same fields will be removed.
+ * A list of persons that enforces uniqueness between its elements and does not
+ * allow nulls. A person is considered unique by comparing using
+ * {@code Person#isSamePerson(Person)}. As such, adding and updating of persons
+ * uses Person#isSamePerson(Person) for equality so as to ensure that the person
+ * being added or updated is unique in terms of identity in the
+ * UniquePersonList. However, the removal of a person uses Person#equals(Object)
+ * so as to ensure that the person with exactly the same fields will be removed.
  *
  * Supports a minimal set of list operations.
  *
@@ -25,8 +28,8 @@ import seedu.address.model.person.exceptions.PersonNotFoundException;
 public class UniquePersonList implements Iterable<Person> {
 
     private final ObservableList<Person> internalList = FXCollections.observableArrayList();
-    private final ObservableList<Person> internalUnmodifiableList =
-            FXCollections.unmodifiableObservableList(internalList);
+    private final ObservableList<Person> internalUnmodifiableList = FXCollections
+            .unmodifiableObservableList(internalList);
 
     /**
      * Returns true if the list contains an equivalent person as the given argument.
@@ -36,9 +39,13 @@ public class UniquePersonList implements Iterable<Person> {
         return internalList.stream().anyMatch(toCheck::isSamePerson);
     }
 
+    public Optional<Person> getPerson(Person person) {
+        requireNonNull(person);
+        return internalList.stream().filter(person::isSamePerson).findFirst();
+    }
+
     /**
-     * Adds a person to the list.
-     * The person must not already exist in the list.
+     * Adds a person to the list. The person must not already exist in the list.
      */
     public void add(Person toAdd) {
         requireNonNull(toAdd);
@@ -50,8 +57,9 @@ public class UniquePersonList implements Iterable<Person> {
 
     /**
      * Replaces the person {@code target} in the list with {@code editedPerson}.
-     * {@code target} must exist in the list.
-     * The person identity of {@code editedPerson} must not be the same as another existing person in the list.
+     * {@code target} must exist in the list. The person identity of
+     * {@code editedPerson} must not be the same as another existing person in the
+     * list.
      */
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
@@ -69,8 +77,8 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
-     * Removes the equivalent person from the list.
-     * The person must exist in the list.
+     * Removes the equivalent person from the list. The person must exist in the
+     * list.
      */
     public void remove(Person toRemove) {
         requireNonNull(toRemove);
@@ -85,8 +93,8 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
-     * Replaces the contents of this list with {@code persons}.
-     * {@code persons} must not contain duplicate persons.
+     * Replaces the contents of this list with {@code persons}. {@code persons} must
+     * not contain duplicate persons.
      */
     public void setPersons(List<Person> persons) {
         requireAllNonNull(persons);

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -129,6 +130,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public Optional<Person> getPerson(Person person) {
+            throw new AssertionError("This methoud should not be called");
+        }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }
@@ -179,6 +185,11 @@ public class AddCommandTest {
         public boolean hasPerson(Person person) {
             requireNonNull(person);
             return this.person.isSamePerson(person);
+        }
+
+        @Override
+        public Optional<Person> getPerson(Person person) {
+            return Optional.of(person);
         }
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -47,7 +47,7 @@ public class PersonTest {
         editedAlice = new PersonBuilder().withName(ALICE.getName().fullName)
                 .withEmail(ALICE.getEmail().value).withPhone(ALICE.getPhone().value)
                 .withSurvey(VALID_SURVEY_BOB).build();
-        assertFalse(ALICE.isSamePerson(editedAlice));
+        assertTrue(ALICE.isSamePerson(editedAlice));
 
         // different name, all other attributes same -> returns false
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();


### PR DESCRIPTION
This resolves #131.

As a summary, with this PR, now if person that only differs in the survey field is added, then we will just append the new surveys to the existing person instead of adding a whole new person.

Note that in this PR, I changed the `isSamePerson` function such that it no longer checks for the survey field. Please let me know if you are relying on this behaviour.

There is also a small change to delete command in this PR where if a user tries to both delete by index and attributes, it will throw an exception.