### PR TITLE
Add changes to UI for done and not done surveys

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -19,6 +19,9 @@ public class PersonCard extends UiPart<Region> {
 
     private static final String DATE_FORMAT = "y-M-d";
 
+    private static final String ID_DONE = "done";
+    private static final String ID_NOT_DONE = "notDone";
+
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
      * As a consequence, UI elements' variable names cannot be set to such keywords
@@ -73,7 +76,11 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().fullName);
         person.getSurveys().stream()
                 .sorted(Comparator.comparing(survey -> survey.survey))
-                .forEach(survey -> surveys.getChildren().add(new Label(survey.survey)));
+                .forEach(survey -> {
+                    Label label = new Label(survey.survey);
+                    label.setId(survey.isDone ? ID_DONE : ID_NOT_DONE);
+                    surveys.getChildren().add(label);
+                });
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -358,9 +358,16 @@
 
 #surveys .label {
     -fx-text-fill: white;
-    -fx-background-color: #3e9144;
     -fx-padding: 2 5 2 5;
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 12;
+}
+
+#surveys #done {
+    -fx-background-color: #3e9144;
+}
+
+#surveys #notDone {
+    -fx-background-color: #eb4034;
 }

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -358,9 +358,16 @@
 
 #surveys .label {
     -fx-text-fill: white;
-    -fx-background-color: #3e9144;
     -fx-padding: 2 5 2 5;
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 12;
+}
+
+#surveys #done {
+    -fx-background-color: #3e9144;
+}
+
+#surveys #notDone {
+    -fx-background-color: #eb4034;
 }


### PR DESCRIPTION
Fixes #141. Extension to @deepimpactmir's mark and unmark command. This will show UI changes to reflect what is done with the commands. Surveys will now have a red background when not marked as done and have a green background when marked as done.