### PR TITLE
Fix wrong case in `delete` example

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -153,7 +153,7 @@ Example:
 
 -   `list` followed by `delete 2` deletes the 2nd person in the app.
 -   `view n/Betsy` followed by `delete 1` deletes the 1st person in the results of the `view` command.
--   `delete ra/Chinese re/christian` Deletes all surveyees that are Chinese and Christian.
+-   `delete ra/Chinese re/Christian` Deletes all surveyees that are Chinese and Christian.
 
 ### Clone a person : `clone`
 


### PR DESCRIPTION
Fix wrong casing in UserGuide. This should really fix #186 .